### PR TITLE
feat(sdk): core-api ports for Python and Groovy (full JS parity)

### DIFF
--- a/packages/core-api-groovy/.gitignore
+++ b/packages/core-api-groovy/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/packages/core-api-groovy/README.md
+++ b/packages/core-api-groovy/README.md
@@ -1,0 +1,64 @@
+# @syngrisi/core-api — Groovy port
+
+A JVM (Groovy) port of the JS package `@syngrisi/core-api`, the client for the
+Syngrisi Visual Testing Platform. Full functional parity with the JS source of
+truth in `packages/core-api/` (SDK version pinned to **3.6.0**).
+
+## Layout
+
+```
+src/main/groovy/io/syngrisi/coreapi/
+  SyngrisiApi.groovy   # API client (constructor, headers, url, requestWithRetry,
+                       # startSession, stopSession, coreCheck/performCheck two-phase,
+                       # getIdent, getBaselines, getSnapshots, acceptCheck, updateBaseline)
+  Utils.groovy         # transformOs, errorObject
+  Compression.groovy   # isCompressedDomDump / compressDomDump / decompressDomDump /
+                       # prepareDomDumpForTransfer (gzip + base64, threshold 50*1024)
+  DomCollector.groovy  # COLLECT_DOM_TREE_SCRIPT constant + getCollectDomTreeScript()
+  Schemas.groovy       # manual validation (throws), STYLES_TO_CAPTURE,
+                       # DOM_DUMP_COMPRESSION_THRESHOLD
+  HttpError.groovy     # carries statusCode/statusMessage (analogous to got HTTPError)
+src/test/groovy/io/syngrisi/coreapi/
+  SyngrisiApiSpec.groovy   # constructor + transformOs (ports SyngrisiApi.test.ts)
+  AuthHeadersSpec.groovy   # auth headers (ports SyngrisiApi.auth-headers.test.ts)
+  FunctionalitySpec.groovy # compression, two-phase coreCheck, retry, guards
+```
+
+## Design
+
+- **Validation throws** `IllegalArgumentException` on invalid input (missing url, bad
+  viewport `^\d+x\d+$`, id length 24, etc.), mirroring zod's `paramsGuard`.
+- **HTTP methods return an error map** (`[error:true, errorMsg:..., statusCode:..., ...]`)
+  instead of throwing, matching the JS ErrorObject contract.
+- HTTP via JDK `java.net.http.HttpClient`; multipart/form-data bodies are built manually.
+  Header names, multipart field names and URL shapes match the JS package exactly.
+- gzip via `java.util.zip`, base64 via `java.util.Base64`, sha512 via `MessageDigest`,
+  JSON via `groovy.json`, urlencode via `URLEncoder`.
+- The HTTP layer is an overridable `requestExecutor` closure (so tests stub it), the
+  retry delay is an overridable `retryDelayMs` (default 2000ms), and the
+  `SYNGRISI_AUTH_TOKEN` source is an overridable `authTokenProvider` closure
+  (defaults to `System.getenv('SYNGRISI_AUTH_TOKEN')`), making auth testable without
+  mutating the process env.
+- The auth-header tests stub a real server with the JDK built-in
+  `com.sun.net.httpserver.HttpServer` on an ephemeral port and assert on the recorded
+  request.
+
+## Running tests
+
+```bash
+source "$HOME/.sdkman/bin/sdkman-init.sh"
+cd packages/core-api-groovy
+gradle test --no-daemon
+```
+
+Versions used: **Groovy 4.0.22**, **Spock 2.3-groovy-4.0**, **JDK 21** (21.0.4-tem).
+
+> Note: Gradle 8.10.2 does not run on JDK 24, and Groovy 4.0.x / Spock target JDK 21.
+> `gradle.properties` pins `org.gradle.java.home` to the sdkman JDK 21 install so the
+> build works regardless of the machine default JDK; `build.gradle` also sets a Java
+> toolchain of 21.
+
+## Behavioral deviations from JS
+
+None. All public surface, field/header names, URL shapes and the two-phase check
+flow match the JS package.

--- a/packages/core-api-groovy/build.gradle
+++ b/packages/core-api-groovy/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'groovy'
+}
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+dependencies {
+    implementation 'org.apache.groovy:groovy:4.0.22'
+    implementation 'org.apache.groovy:groovy-json:4.0.22'
+
+    testImplementation platform('org.spockframework:spock-bom:2.3-groovy-4.0')
+    testImplementation 'org.spockframework:spock-core'
+    testImplementation 'org.apache.groovy:groovy-json:4.0.22'
+}
+
+test {
+    useJUnitPlatform()
+    testLogging {
+        events 'passed', 'skipped', 'failed'
+        exceptionFormat 'full'
+    }
+}

--- a/packages/core-api-groovy/gradle.properties
+++ b/packages/core-api-groovy/gradle.properties
@@ -1,0 +1,6 @@
+# Gradle 8.10.2 does not run on JDK 24+. Launch Gradle with a JDK 17–22 — the build then
+# compiles and runs tests with the Java 21 toolchain configured in build.gradle (Gradle
+# auto-detects an installed JDK 21, e.g. via sdkman). Examples:
+#   JAVA_HOME="$(sdk home java 21.0.4-tem)" gradle test
+#   # or set org.gradle.java.home to a local JDK 21 path (do not commit a machine path)
+org.gradle.daemon=false

--- a/packages/core-api-groovy/settings.gradle
+++ b/packages/core-api-groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'core-api-groovy'

--- a/packages/core-api-groovy/src/main/groovy/io/syngrisi/coreapi/Compression.groovy
+++ b/packages/core-api-groovy/src/main/groovy/io/syngrisi/coreapi/Compression.groovy
@@ -1,0 +1,142 @@
+package io.syngrisi.coreapi
+
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
+
+/**
+ * Port of src/compression.ts — gzip + base64 DOM dump compression.
+ * Threshold = 50 * 1024 bytes.
+ */
+class Compression {
+
+    static final int DOM_DUMP_COMPRESSION_THRESHOLD = Schemas.DOM_DUMP_COMPRESSION_THRESHOLD
+
+    /**
+     * Checks if the given data is in compressed DomDump format.
+     * true iff map-like with compressed==true and string data.
+     */
+    static boolean isCompressedDomDump(Object data) {
+        if (!(data instanceof Map)) {
+            return false
+        }
+        Map m = data as Map
+        return m.containsKey('compressed') &&
+                m.compressed == true &&
+                m.containsKey('data') &&
+                (m.data instanceof CharSequence)
+    }
+
+    /**
+     * Compresses DomDump if it exceeds the threshold size.
+     * Returns original JSON string if below threshold, or a compressed map if large.
+     *
+     * @param domDump DomNode tree (Map/List) or JSON string
+     * @return String if small, or Map [data, compressed:true, originalSize] if compressed
+     */
+    static Object compressDomDump(Object domDump) {
+        String jsonString = (domDump instanceof CharSequence)
+                ? domDump.toString()
+                : JsonOutput.toJson(domDump)
+
+        byte[] utf8 = jsonString.getBytes('UTF-8')
+        int originalSize = utf8.length
+
+        // Skip compression for small payloads
+        if (originalSize <= DOM_DUMP_COMPRESSION_THRESHOLD) {
+            return jsonString
+        }
+
+        byte[] compressed = gzip(utf8)
+
+        return [
+                data        : Base64.encoder.encodeToString(compressed),
+                compressed  : true,
+                originalSize: originalSize,
+        ]
+    }
+
+    /**
+     * Decompresses DomDump if it was compressed. Handles both compressed and
+     * uncompressed formats. Returns parsed DomNode object or null if invalid.
+     */
+    static Object decompressDomDump(Object data) {
+        try {
+            // Already a DomNode object (map/list, not compressed)
+            if ((data instanceof Map || data instanceof List) && !isCompressedDomDump(data)) {
+                return data
+            }
+
+            // Compressed format
+            if (isCompressedDomDump(data)) {
+                byte[] buffer = Base64.decoder.decode((data as Map).data.toString())
+                String decompressed = new String(gunzip(buffer), 'UTF-8')
+                return new JsonSlurper().parseText(decompressed)
+            }
+
+            // JSON string
+            if (data instanceof CharSequence) {
+                Object parsed = new JsonSlurper().parseText(data.toString())
+                if (isCompressedDomDump(parsed)) {
+                    return decompressDomDump(parsed)
+                }
+                return parsed
+            }
+
+            return null
+        } catch (Exception e) {
+            System.err.println("Failed to decompress domDump: ${e}")
+            return null
+        }
+    }
+
+    /**
+     * Prepares DomDump for sending to the server.
+     * Returns [data: String, isCompressed: boolean].
+     */
+    static Map prepareDomDumpForTransfer(Object domDump) {
+        // If already compressed, just stringify it
+        if (isCompressedDomDump(domDump)) {
+            return [
+                    data        : JsonOutput.toJson(domDump),
+                    isCompressed: true,
+            ]
+        }
+
+        Object result = compressDomDump(domDump)
+
+        if (isCompressedDomDump(result)) {
+            return [
+                    data        : JsonOutput.toJson(result),
+                    isCompressed: true,
+            ]
+        }
+
+        return [
+                data        : (String) result,
+                isCompressed: false,
+        ]
+    }
+
+    private static byte[] gzip(byte[] input) {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        GZIPOutputStream gz = new GZIPOutputStream(baos)
+        gz.write(input)
+        gz.close()
+        return baos.toByteArray()
+    }
+
+    private static byte[] gunzip(byte[] input) {
+        GZIPInputStream gz = new GZIPInputStream(new ByteArrayInputStream(input))
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        byte[] buf = new byte[8192]
+        int n
+        while ((n = gz.read(buf)) != -1) {
+            baos.write(buf, 0, n)
+        }
+        gz.close()
+        return baos.toByteArray()
+    }
+}

--- a/packages/core-api-groovy/src/main/groovy/io/syngrisi/coreapi/DomCollector.groovy
+++ b/packages/core-api-groovy/src/main/groovy/io/syngrisi/coreapi/DomCollector.groovy
@@ -1,0 +1,172 @@
+package io.syngrisi.coreapi
+
+/**
+ * Port of src/domCollector.ts.
+ *
+ * The collectDomTree runtime function is browser-only (runs via page.evaluate()).
+ * For JVM parity we expose the injectable script string verbatim plus an accessor,
+ * mirroring COLLECT_DOM_TREE_SCRIPT / getCollectDomTreeScript() from the JS package.
+ */
+class DomCollector {
+
+    /**
+     * Source text of the collectDomTree function, exactly as it appears in
+     * src/domCollector.ts (the value of collectDomTree.toString() at runtime).
+     * Kept as a single-quoted Groovy string so the JS ${...} template literals
+     * inside it remain literal.
+     */
+    private static final String COLLECT_DOM_TREE_FN = '''function collectDomTree() {
+    /**
+     * Check if element is visible (has dimensions and not hidden)
+     */
+    function isVisible(el) {
+        const style = window.getComputedStyle(el)
+        if (
+            style.display === 'none' ||
+            style.visibility === 'hidden' ||
+            parseFloat(style.opacity) === 0
+        ) {
+            return false
+        }
+        const rect = el.getBoundingClientRect()
+        return rect.width > 0 && rect.height > 0
+    }
+
+    /**
+     * Extract relevant attributes from element
+     * Skips most data-* attributes to reduce payload size
+     */
+    function getAttributes(el) {
+        const attrs = {}
+        for (const attr of Array.from(el.attributes)) {
+            // Include data-testid but skip other data-* attributes
+            if (!attr.name.startsWith('data-') || attr.name === 'data-testid') {
+                attrs[attr.name] = attr.value
+            }
+        }
+        return attrs
+    }
+
+    /**
+     * Extract computed styles that affect visual appearance
+     */
+    function getComputedStyles(el) {
+        const computed = window.getComputedStyle(el)
+        const styles = {}
+
+        const stylesToCapture = [
+            // Display & Visibility
+            'display', 'visibility', 'opacity',
+            // Position
+            'position', 'top', 'right', 'bottom', 'left',
+            // Dimensions
+            'width', 'height', 'min-width', 'min-height', 'max-width', 'max-height',
+            // Box Model
+            'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left',
+            'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left',
+            'border', 'border-width', 'border-style', 'border-color',
+            'border-radius',
+            // Colors
+            'background-color', 'color',
+            // Typography
+            'font-family', 'font-size', 'font-weight', 'line-height', 'text-align',
+            'text-decoration', 'text-transform', 'letter-spacing',
+            // Layout
+            'overflow', 'overflow-x', 'overflow-y',
+            'z-index',
+            'transform',
+            // Flexbox
+            'flex', 'flex-direction', 'flex-wrap', 'justify-content', 'align-items', 'align-content', 'gap',
+            // Grid
+            'grid-template-columns', 'grid-template-rows', 'grid-gap',
+            // Box Shadow
+            'box-shadow',
+        ]
+
+        for (const prop of stylesToCapture) {
+            const value = computed.getPropertyValue(prop)
+            // Skip default/empty values to reduce payload
+            if (value && value !== 'initial' && value !== 'none' && value !== 'normal' && value !== 'auto' && value !== '0px' && value !== 'rgba(0, 0, 0, 0)') {
+                // Convert kebab-case to camelCase for consistency
+                const camelProp = prop.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase())
+                styles[camelProp] = value
+            }
+        }
+        return styles
+    }
+
+    /**
+     * Get direct text content (not from children)
+     */
+    function getDirectText(el) {
+        let text = \'\'
+        for (const child of Array.from(el.childNodes)) {
+            if (child.nodeType === Node.TEXT_NODE) {
+                text += child.textContent?.trim() || \'\'
+            }
+        }
+        // Truncate long text
+        const trimmed = text.trim()
+        if (!trimmed) return undefined
+        return trimmed.length > 200 ? trimmed.substring(0, 200) + \'...\' : trimmed
+    }
+
+    /**
+     * Recursively collect DOM node and its children
+     */
+    function collectNode(el, depth = 0) {
+        // Limit depth to prevent stack overflow
+        if (depth > 15) return null
+
+        // Skip invisible elements
+        if (!isVisible(el)) return null
+
+        // Skip non-visual elements
+        const skipTags = ['SCRIPT', 'STYLE', 'NOSCRIPT', 'META', 'LINK', 'HEAD', 'SVG', 'PATH']
+        if (skipTags.includes(el.tagName)) return null
+
+        const rect = el.getBoundingClientRect()
+
+        // Collect children
+        const children = []
+        for (const child of Array.from(el.children)) {
+            const childNode = collectNode(child, depth + 1)
+            if (childNode) {
+                children.push(childNode)
+            }
+        }
+
+        return {
+            tagName: el.tagName.toLowerCase(),
+            attributes: getAttributes(el),
+            rect: {
+                x: Math.round(rect.x),
+                y: Math.round(rect.y),
+                width: Math.round(rect.width),
+                height: Math.round(rect.height),
+            },
+            computedStyles: getComputedStyles(el),
+            children,
+            text: getDirectText(el),
+        }
+    }
+
+    const root = collectNode(document.body)
+    return JSON.stringify(root)
+}'''
+
+    /**
+     * String version of collectDomTree for browser injection.
+     * Mirrors COLLECT_DOM_TREE_SCRIPT from the JS package:
+     *   `\\n(function() {\\n    ${collectDomTree.toString()}\\n    return collectDomTree();\\n})()\\n`
+     */
+    static final String COLLECT_DOM_TREE_SCRIPT = "\n(function() {\n    " +
+            COLLECT_DOM_TREE_FN + "\n    return collectDomTree();\n})()\n"
+
+    /**
+     * Creates the DOM collection script that can be injected into a browser context.
+     */
+    static String getCollectDomTreeScript() {
+        return COLLECT_DOM_TREE_SCRIPT
+    }
+}

--- a/packages/core-api-groovy/src/main/groovy/io/syngrisi/coreapi/HttpError.groovy
+++ b/packages/core-api-groovy/src/main/groovy/io/syngrisi/coreapi/HttpError.groovy
@@ -1,0 +1,19 @@
+package io.syngrisi.coreapi
+
+/**
+ * Error raised for non-2xx HTTP responses.
+ * Analogous to got's HTTPError where e.response.statusCode / e.response.statusMessage
+ * are available — here exposed directly as statusCode / statusMessage.
+ */
+class HttpError extends RuntimeException {
+    final int statusCode
+    final String statusMessage
+    final String body
+
+    HttpError(int statusCode, String statusMessage, String body) {
+        super("Response code ${statusCode} (${statusMessage})".toString())
+        this.statusCode = statusCode
+        this.statusMessage = statusMessage
+        this.body = body
+    }
+}

--- a/packages/core-api-groovy/src/main/groovy/io/syngrisi/coreapi/Schemas.groovy
+++ b/packages/core-api-groovy/src/main/groovy/io/syngrisi/coreapi/Schemas.groovy
@@ -1,0 +1,207 @@
+package io.syngrisi.coreapi
+
+import groovy.json.JsonOutput
+
+/**
+ * Manual validation that mirrors the zod schemas from the JS package.
+ * Each guard throws IllegalArgumentException on invalid input, matching zod's
+ * "throw on invalid" behaviour (paramsGuard in the JS utils).
+ */
+class Schemas {
+
+    static final int DOM_DUMP_COMPRESSION_THRESHOLD = 50 * 1024
+
+    /**
+     * CSS properties to capture for RCA analysis.
+     * Mirrors STYLES_TO_CAPTURE from DomNode.schema.ts (camelCase variant).
+     */
+    static final List<String> STYLES_TO_CAPTURE = [
+            // Display & Visibility
+            'display', 'visibility', 'opacity',
+            // Position
+            'position', 'top', 'right', 'bottom', 'left',
+            // Dimensions
+            'width', 'height', 'minWidth', 'minHeight', 'maxWidth', 'maxHeight',
+            // Box Model
+            'margin', 'marginTop', 'marginRight', 'marginBottom', 'marginLeft',
+            'padding', 'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft',
+            'border', 'borderWidth', 'borderStyle', 'borderColor',
+            'borderRadius',
+            // Colors
+            'backgroundColor', 'color',
+            // Typography
+            'fontFamily', 'fontSize', 'fontWeight', 'lineHeight', 'textAlign',
+            'textDecoration', 'textTransform', 'letterSpacing',
+            // Layout
+            'overflow', 'overflowX', 'overflowY',
+            'zIndex',
+            'transform',
+            // Flexbox
+            'flex', 'flexDirection', 'flexWrap', 'justifyContent', 'alignItems', 'alignContent', 'gap',
+            // Grid
+            'gridTemplateColumns', 'gridTemplateRows', 'gridGap',
+            // Box Shadow
+            'boxShadow',
+    ].asImmutable()
+
+    private static final java.util.regex.Pattern VIEWPORT_REGEX = ~/^\d+x\d+$/
+
+    private static void fail(String functionName, String detail, Object params) {
+        throw new IllegalArgumentException(
+                "Invalid '${functionName}' parameters: ${detail}\n params: ${JsonOutput.toJson(params)}".toString())
+    }
+
+    private static boolean isNonEmptyString(Object v) {
+        return (v instanceof CharSequence) && v.toString().length() > 0
+    }
+
+    private static void requireNonEmptyString(Map params, String key, String functionName) {
+        if (!isNonEmptyString(params[key])) {
+            fail(functionName, "field '${key}' must be a non-empty string", params)
+        }
+    }
+
+    private static void requireString(Map params, String key, String functionName) {
+        if (!(params[key] instanceof CharSequence)) {
+            fail(functionName, "field '${key}' must be a string", params)
+        }
+    }
+
+    private static void requireViewport(Map params, String key, String functionName) {
+        Object v = params[key]
+        if (!isNonEmptyString(v) || v.toString().length() < 3 || !VIEWPORT_REGEX.matcher(v.toString()).matches()) {
+            fail(functionName, "field '${key}' must match viewport format WxH (e.g. '1200x800')", params)
+        }
+    }
+
+    private static void requireIdString(Map params, String key, String functionName) {
+        Object v = params[key]
+        if (!(v instanceof CharSequence) || v.toString().length() != 24) {
+            fail(functionName, "field '${key}' must be a 24-character id string", params)
+        }
+    }
+
+    private static void requireStringOrNumber(Map params, String key, String functionName) {
+        Object v = params[key]
+        if (v instanceof Number) {
+            return
+        }
+        if (!isNonEmptyString(v)) {
+            fail(functionName, "field '${key}' must be a non-empty string or a number", params)
+        }
+    }
+
+    /** ConfigSchema: url non-empty str; apiKey optional str; headers optional map<str,str>. */
+    static void validateConfig(Map cfg, String functionName) {
+        if (cfg == null) {
+            fail(functionName, 'config must be provided', cfg)
+        }
+        requireNonEmptyString(cfg, 'url', functionName)
+        if (cfg.containsKey('apiKey') && cfg.apiKey != null && !(cfg.apiKey instanceof CharSequence)) {
+            fail(functionName, "field 'apiKey' must be a string", cfg)
+        }
+        if (cfg.containsKey('headers') && cfg.headers != null) {
+            if (!(cfg.headers instanceof Map)) {
+                fail(functionName, "field 'headers' must be a map", cfg)
+            }
+            (cfg.headers as Map).each { k, v ->
+                if (!(k instanceof CharSequence) || !(v instanceof CharSequence)) {
+                    fail(functionName, "field 'headers' must be a map of string->string", cfg)
+                }
+            }
+        }
+    }
+
+    /** ApiSessionParamsSchema. */
+    static void validateApiSessionParams(Map params, String functionName) {
+        if (params == null) {
+            fail(functionName, 'params must be provided', params)
+        }
+        requireNonEmptyString(params, 'run', functionName)
+        requireNonEmptyString(params, 'suite', functionName)
+        requireNonEmptyString(params, 'runident', functionName)
+        requireNonEmptyString(params, 'name', functionName)
+        requireViewport(params, 'viewport', functionName)
+        requireNonEmptyString(params, 'browser', functionName)
+        requireStringOrNumber(params, 'browserVersion', functionName)
+        requireNonEmptyString(params, 'browserFullVersion', functionName)
+        requireString(params, 'os', functionName)
+        requireString(params, 'app', functionName)
+        if (params.containsKey('tags') && params.tags != null) {
+            if (!(params.tags instanceof List) || !(params.tags as List).every { it instanceof CharSequence }) {
+                fail(functionName, "field 'tags' must be an array of strings", params)
+            }
+        }
+        requireString(params, 'branch', functionName)
+    }
+
+    /** CheckParamsSchema. */
+    static void validateCheckParams(Map params, String functionName) {
+        if (params == null) {
+            fail(functionName, 'params must be provided', params)
+        }
+        requireNonEmptyString(params, 'name', functionName)
+        requireViewport(params, 'viewport', functionName)
+        requireNonEmptyString(params, 'browserName', functionName)
+        requireNonEmptyString(params, 'os', functionName)
+        requireNonEmptyString(params, 'app', functionName)
+        requireNonEmptyString(params, 'branch', functionName)
+        requireIdString(params, 'testId', functionName)
+        requireNonEmptyString(params, 'suite', functionName)
+        requireStringOrNumber(params, 'browserVersion', functionName)
+        requireNonEmptyString(params, 'browserFullVersion', functionName)
+        Object hashCode = params.hashCode
+        if (!(hashCode instanceof CharSequence) || hashCode.toString().length() < 64) {
+            fail(functionName, "field 'hashCode' must be a string of at least 64 chars", params)
+        }
+        if (params.containsKey('skipDomData') && params.skipDomData != null && !(params.skipDomData instanceof Boolean)) {
+            fail(functionName, "field 'skipDomData' must be a boolean", params)
+        }
+        if (params.containsKey('toleranceThreshold') && params.toleranceThreshold != null) {
+            Object t = params.toleranceThreshold
+            if (!(t instanceof Number) || (t as Number).doubleValue() < 0 || (t as Number).doubleValue() > 100) {
+                fail(functionName, "field 'toleranceThreshold' must be a number between 0 and 100", params)
+            }
+        }
+    }
+
+    /** BaselineParamsSchema. */
+    static void validateBaselineParams(Map params, String functionName) {
+        if (params == null) {
+            fail(functionName, 'params must be provided', params)
+        }
+        requireNonEmptyString(params, 'name', functionName)
+        requireViewport(params, 'viewport', functionName)
+        requireNonEmptyString(params, 'browserName', functionName)
+        requireNonEmptyString(params, 'os', functionName)
+        requireNonEmptyString(params, 'app', functionName)
+        requireNonEmptyString(params, 'branch', functionName)
+    }
+
+    /** SnapshotSchema: all fields optional. */
+    static void validateSnapshot(Map params, String functionName) {
+        if (params == null) {
+            fail(functionName, 'params must be provided', params)
+        }
+        if (params.containsKey('_id') && params._id != null) {
+            requireIdString(params, '_id', functionName)
+        }
+        if (params.containsKey('name') && params.name != null) {
+            requireNonEmptyString(params, 'name', functionName)
+        }
+        if (params.containsKey('filename') && params.filename != null) {
+            requireNonEmptyString(params, 'filename', functionName)
+        }
+        if (params.containsKey('imghash') && params.imghash != null) {
+            Object v = params.imghash
+            if (!(v instanceof CharSequence) || v.toString().length() != 128) {
+                fail(functionName, "field 'imghash' must be a 128-character string", params)
+            }
+        }
+        if (params.containsKey('createdDate') && params.createdDate != null) {
+            if (!(params.createdDate instanceof Date)) {
+                fail(functionName, "field 'createdDate' must be a Date", params)
+            }
+        }
+    }
+}

--- a/packages/core-api-groovy/src/main/groovy/io/syngrisi/coreapi/SyngrisiApi.groovy
+++ b/packages/core-api-groovy/src/main/groovy/io/syngrisi/coreapi/SyngrisiApi.groovy
@@ -1,0 +1,378 @@
+package io.syngrisi.coreapi
+
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+/**
+ * Groovy port of src/SyngrisiApi.ts — the Syngrisi visual regression API client.
+ *
+ * Parity notes:
+ *  - Validation throws IllegalArgumentException (mirrors zod paramsGuard "throw on invalid").
+ *  - HTTP methods return an error map ([error:true, ...]) instead of throwing.
+ *  - Header names, multipart field names and URL shapes match the JS package exactly.
+ */
+class SyngrisiApi {
+
+    /** SDK version — pinned to the JS package.json version. */
+    static final String SDK_VERSION = '3.6.0'
+
+    private final Map config
+
+    /**
+     * Source of the SYNGRISI_AUTH_TOKEN fallback. Defaults to the real env var but
+     * is overridable so tests can inject a value without mutating the process env.
+     */
+    Closure<String> authTokenProvider = { -> System.getenv('SYNGRISI_AUTH_TOKEN') }
+
+    /** Retry delay in ms (default 2000, overridable so tests run fast). */
+    int retryDelayMs = 2000
+
+    private final int maxRetries = 3
+
+    /**
+     * HTTP executor. Receives a request descriptor map and must return the parsed
+     * JSON response, or throw HttpError on a non-2xx response. Overridable in tests.
+     *
+     * Descriptor keys:
+     *   method  : 'GET' | 'POST' | 'PUT'
+     *   url     : String
+     *   headers : Map<String,String>
+     *   multipart : List of field maps (optional) — [name, value, filename?, bytes?]
+     *   json    : Object to send as application/json body (optional)
+     */
+    Closure requestExecutor
+
+    SyngrisiApi(Map cfg) {
+        Schemas.validateConfig(cfg, 'SyngrisiApi, constructor, cfg')
+        // Copy so we can attach apiHash without mutating caller's map.
+        this.config = new LinkedHashMap(cfg)
+        this.config.apiHash = hasha((cfg.apiKey ?: '').toString())
+        this.requestExecutor = this.&defaultExecute
+    }
+
+    /** SHA-512 hex of input (matches the JS hasha() helper). */
+    private static String hasha(String input) {
+        MessageDigest md = MessageDigest.getInstance('SHA-512')
+        byte[] digest = md.digest(input.getBytes(StandardCharsets.UTF_8))
+        StringBuilder sb = new StringBuilder()
+        for (byte b : digest) {
+            sb.append(String.format('%02x', b))
+        }
+        return sb.toString()
+    }
+
+    /** Common request headers (apikey, sdk version, hybrid auth fallback). */
+    private Map<String, String> getHeaders() {
+        Map<String, String> headers = [:]
+        headers['x-syngrisi-sdk-version'] = SDK_VERSION
+        if (config.headers) {
+            (config.headers as Map).each { k, v -> headers[k.toString()] = v.toString() }
+        }
+        if (config.apiKey) {
+            headers['apikey'] = config.apiHash.toString()
+        }
+        // Hybrid Auth: fall back to env token if no Authorization header set.
+        if (!headers.containsKey('Authorization') && !headers.containsKey('authorization')) {
+            String token = authTokenProvider.call()
+            if (token) {
+                headers['Authorization'] = "Bearer ${token}".toString()
+            }
+        }
+        return headers
+    }
+
+    /** Builds the client URL: `${config.url}v1/client/${itemName}`. */
+    private String url(String itemName) {
+        return "${config.url}v1/client/${itemName}".toString()
+    }
+
+    private Object requestWithRetry(Closure requestFn, String methodName, String errorMessage) {
+        for (int attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                return requestFn.call()
+            } catch (Exception e) {
+                boolean is401 = (e instanceof HttpError) && ((HttpError) e).statusCode == 401
+                boolean isLastAttempt = attempt == maxRetries
+                if (is401 && !isLastAttempt) {
+                    if (retryDelayMs > 0) {
+                        Thread.sleep(retryDelayMs)
+                    }
+                    continue
+                }
+                return Utils.errorObject(e)
+            }
+        }
+        return Utils.errorObject(new RuntimeException('Max retries exceeded'))
+    }
+
+    Object startSession(Map params) {
+        Schemas.validateApiSessionParams(params, 'startSession, params')
+        return requestWithRetry({
+            List<Map> multipart = []
+            ['run', 'suite', 'runident', 'name', 'viewport', 'browser', 'browserVersion', 'os', 'app'].each { p ->
+                multipart << [name: p, value: params[p]?.toString()]
+            }
+            if (params.tags) {
+                multipart << [name: 'tags', value: JsonOutput.toJson(params.tags)]
+            }
+            if (params.branch) {
+                multipart << [name: 'branch', value: params.branch.toString()]
+            }
+            return requestExecutor([
+                    method   : 'POST',
+                    url      : url('startSession'),
+                    headers  : getHeaders(),
+                    multipart: multipart,
+            ])
+        }, 'startSession', '❌ Error posting start session data')
+    }
+
+    Object stopSession(String testId) {
+        return requestWithRetry({
+            return requestExecutor([
+                    method   : 'POST',
+                    url      : "${url('stopSession')}/${testId}".toString(),
+                    headers  : getHeaders(),
+                    multipart: [],
+            ])
+        }, 'stopSession', "❌ Error posting stop session data for test: '${testId}'".toString())
+    }
+
+    private Map addMessageIfCheckFailed(Object result) {
+        if (!(result instanceof Map)) {
+            return result
+        }
+        Map patchedResult = result as Map
+        if (patchedResult.error || !(patchedResult.status instanceof CharSequence)) {
+            return patchedResult
+        }
+        if (patchedResult.status.toString().contains('failed')) {
+            String checkView = "'${config.url}?checkId=${patchedResult._id}&modalIsOpen=true'".toString()
+            patchedResult.message = "To evaluate the results of the check, follow the link: '${checkView}'".toString()
+            patchedResult.vrsGroupLink = checkView
+            patchedResult.vrsDiffLink = checkView
+        }
+        return patchedResult
+    }
+
+    Object coreCheck(byte[] imageBuffer, Map params) {
+        Object resultWithHash = performCheck(params, null, params.hashCode?.toString())
+        resultWithHash = addMessageIfCheckFailed(resultWithHash)
+
+        if ((resultWithHash instanceof Map) && resultWithHash.status == 'requiredFileData') {
+            Object resultWithFile = performCheck(params, imageBuffer, params.hashCode?.toString())
+            resultWithFile = addMessageIfCheckFailed(resultWithFile)
+            return resultWithFile
+        }
+        return resultWithHash
+    }
+
+    private Object performCheck(Map params, byte[] imageBuffer, String hashCode) {
+        Schemas.validateCheckParams(params, 'createCheck, params')
+
+        String checkUrl = url('createCheck')
+        // params field -> multipart field name
+        Map<String, String> fieldsMapping = [
+                branch            : 'branch',
+                app               : 'appName',
+                suite             : 'suitename',
+                vShifting         : 'vShifting',
+                testId            : 'testid',
+                name              : 'name',
+                viewport          : 'viewport',
+                browserName       : 'browserName',
+                browserVersion    : 'browserVersion',
+                browserFullVersion: 'browserFullVersion',
+                os                : 'os',
+                toleranceThreshold: 'toleranceThreshold',
+        ]
+
+        return requestWithRetry({
+            List<Map> multipart = []
+            Map<String, String> requestHeaders = getHeaders()
+
+            fieldsMapping.each { key, fieldName ->
+                if (params[key] != null) {
+                    multipart << [name: fieldName, value: params[key].toString()]
+                }
+            }
+
+            boolean shouldSkipDom = isDomDataDisabled() || params.skipDomData == true
+            if (params.domDump && !shouldSkipDom) {
+                Map prepared = Compression.prepareDomDumpForTransfer(params.domDump)
+                multipart << [name: 'domdump', value: prepared.data]
+                if (prepared.isCompressed) {
+                    requestHeaders['x-domdump-compressed'] = 'gzip'
+                }
+            }
+
+            if (hashCode) {
+                multipart << [name: 'hashcode', value: hashCode]
+            }
+            if (imageBuffer != null) {
+                multipart << [name: 'file', filename: 'file', bytes: imageBuffer]
+            }
+
+            return requestExecutor([
+                    method   : 'POST',
+                    url      : checkUrl,
+                    headers  : requestHeaders,
+                    multipart: multipart,
+            ])
+        }, 'createCheck', "❌ Error posting create check data params: '${JsonOutput.toJson(params)}'".toString())
+    }
+
+    Object getIdent() {
+        String reqUrl = config.apiKey
+                ? "${url('getIdent')}?apikey=${config.apiHash}".toString()
+                : url('getIdent')
+        return requestWithRetry({
+            return requestExecutor([method: 'GET', url: reqUrl, headers: getHeaders()])
+        }, 'getIdent', '❌ Error getting ident data')
+    }
+
+    Object getBaselines(Map params) {
+        Schemas.validateBaselineParams(params, 'getBaselines, params')
+        String filter = URLEncoder.encode(JsonOutput.toJson(params), 'UTF-8')
+        String reqUrl = config.apiKey
+                ? "${url('baselines')}?filter=${filter}&apikey=${config.apiHash}".toString()
+                : "${url('baselines')}?filter=${filter}".toString()
+        return requestWithRetry({
+            return requestExecutor([method: 'GET', url: reqUrl, headers: getHeaders()])
+        }, 'getBaselines', "❌ Error getting baselines, params: '${JsonOutput.toJson(params)}' data".toString())
+    }
+
+    Object getSnapshots(Map params) {
+        Schemas.validateSnapshot(params, 'getSnapshots, params')
+        String filter = URLEncoder.encode(JsonOutput.toJson(params), 'UTF-8')
+        String reqUrl = config.apiKey
+                ? "${url('snapshots')}?filter=${filter}&apikey=${config.apiHash}".toString()
+                : "${url('snapshots')}?filter=${filter}".toString()
+        return requestWithRetry({
+            return requestExecutor([method: 'GET', url: reqUrl, headers: getHeaders()])
+        }, 'getSnapshots', "❌ Error getting snapshots, params: '${JsonOutput.toJson(params)}' data".toString())
+    }
+
+    Object acceptCheck(String checkId, String baselineId) {
+        if (!checkId) {
+            return Utils.errorObject(new RuntimeException('checkId is required'))
+        }
+        if (!baselineId) {
+            return Utils.errorObject(new RuntimeException('baselineId is required'))
+        }
+        return requestWithRetry({
+            String reqUrl = "${config.url}v1/checks/${checkId}/accept".toString()
+            return requestExecutor([
+                    method : 'PUT',
+                    url    : reqUrl,
+                    headers: getHeaders(),
+                    json   : [baselineId: baselineId],
+            ])
+        }, 'acceptCheck', "❌ Error accepting check, checkId: '${checkId}', baselineId: '${baselineId}'".toString())
+    }
+
+    Object updateBaseline(String baselineId, Map updates) {
+        if (!baselineId) {
+            return Utils.errorObject(new RuntimeException('baselineId is required'))
+        }
+        String reqUrl = "${config.url}v1/baselines/${baselineId}".toString()
+        return requestWithRetry({
+            return requestExecutor([
+                    method : 'PUT',
+                    url    : reqUrl,
+                    headers: getHeaders(),
+                    json   : updates,
+            ])
+        }, 'updateBaseline', "❌ Error updating baseline, baselineId: '${baselineId}', updates: '${JsonOutput.toJson(updates)}'".toString())
+    }
+
+    private static boolean isDomDataDisabled() {
+        return System.getenv('SYNGRISI_DISABLE_DOM_DATA') == 'true'
+    }
+
+    // ---- Default HTTP executor backed by JDK HttpClient ----
+
+    private Object defaultExecute(Map req) {
+        HttpClient client = HttpClient.newHttpClient()
+        HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(req.url.toString()))
+
+        Map<String, String> headers = (req.headers ?: [:]) as Map
+
+        HttpRequest.BodyPublisher body
+        if (req.json != null) {
+            body = HttpRequest.BodyPublishers.ofString(JsonOutput.toJson(req.json))
+            headers = new LinkedHashMap(headers)
+            headers['Content-Type'] = 'application/json'
+        } else if (req.containsKey('multipart')) {
+            String boundary = "----SyngrisiBoundary${System.nanoTime()}".toString()
+            byte[] multipartBody = buildMultipart((List<Map>) (req.multipart ?: []), boundary)
+            body = HttpRequest.BodyPublishers.ofByteArray(multipartBody)
+            headers = new LinkedHashMap(headers)
+            headers['Content-Type'] = "multipart/form-data; boundary=${boundary}".toString()
+        } else {
+            body = HttpRequest.BodyPublishers.noBody()
+        }
+
+        headers.each { k, v -> builder.header(k, v) }
+
+        switch (req.method) {
+            case 'GET':
+                builder.GET()
+                break
+            case 'POST':
+                builder.POST(body)
+                break
+            case 'PUT':
+                builder.PUT(body)
+                break
+            default:
+                throw new IllegalArgumentException("Unsupported method: ${req.method}")
+        }
+
+        HttpResponse<String> response = client.send(builder.build(), HttpResponse.BodyHandlers.ofString())
+        int status = response.statusCode()
+        if (status < 200 || status >= 300) {
+            throw new HttpError(status, statusMessageFor(status), response.body())
+        }
+        return new JsonSlurper().parseText(response.body())
+    }
+
+    private static byte[] buildMultipart(List<Map> fields, String boundary) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream()
+        String dashBoundary = "--${boundary}\r\n"
+        fields.each { field ->
+            out.write(dashBoundary.getBytes(StandardCharsets.UTF_8))
+            if (field.bytes != null) {
+                String header = "Content-Disposition: form-data; name=\"${field.name}\"; filename=\"${field.filename ?: field.name}\"\r\n" +
+                        "Content-Type: application/octet-stream\r\n\r\n"
+                out.write(header.getBytes(StandardCharsets.UTF_8))
+                out.write((byte[]) field.bytes)
+            } else {
+                String header = "Content-Disposition: form-data; name=\"${field.name}\"\r\n\r\n"
+                out.write(header.getBytes(StandardCharsets.UTF_8))
+                out.write((field.value ?: '').toString().getBytes(StandardCharsets.UTF_8))
+            }
+            out.write("\r\n".getBytes(StandardCharsets.UTF_8))
+        }
+        out.write("--${boundary}--\r\n".toString().getBytes(StandardCharsets.UTF_8))
+        return out.toByteArray()
+    }
+
+    private static String statusMessageFor(int status) {
+        switch (status) {
+            case 400: return 'Bad Request'
+            case 401: return 'Unauthorized'
+            case 403: return 'Forbidden'
+            case 404: return 'Not Found'
+            case 500: return 'Internal Server Error'
+            default: return ''
+        }
+    }
+}

--- a/packages/core-api-groovy/src/main/groovy/io/syngrisi/coreapi/Utils.groovy
+++ b/packages/core-api-groovy/src/main/groovy/io/syngrisi/coreapi/Utils.groovy
@@ -1,0 +1,58 @@
+package io.syngrisi.coreapi
+
+/**
+ * Port of src/utils.ts — transformOs and errorObject helpers.
+ */
+class Utils {
+
+    /**
+     * Transforms a platform string to a standardized OS name.
+     * Lowercases input, then maps known platforms; otherwise returns the
+     * original (un-lowercased) input.
+     */
+    static String transformOs(String platform) {
+        String lowercasePlatform = platform.toLowerCase()
+        Map<String, String> transform = [
+                win32    : 'WINDOWS',
+                windows  : 'WINDOWS',
+                macintel : 'macOS',
+                'mac os' : 'macOS',
+        ]
+        return transform.containsKey(lowercasePlatform) ? transform[lowercasePlatform] : platform
+    }
+
+    /**
+     * Builds an ErrorObject map from a throwable / HttpError.
+     * Mirrors errorObject(e) in utils.ts:
+     *   { error: true, errorMsg: e.toString(), statusCode?, statusMessage?, stack? }
+     */
+    static Map errorObject(Object e) {
+        Map result = [
+                error   : true,
+                errorMsg: e?.toString(),
+        ]
+
+        Integer statusCode = null
+        String statusMessage = null
+        String stack = null
+
+        if (e instanceof HttpError) {
+            statusCode = (e as HttpError).statusCode
+            statusMessage = (e as HttpError).statusMessage
+            stack = stackTrace(e)
+        } else if (e instanceof Throwable) {
+            stack = stackTrace((Throwable) e)
+        }
+
+        result.statusCode = statusCode
+        result.statusMessage = statusMessage
+        result.stack = stack
+        return result
+    }
+
+    private static String stackTrace(Throwable t) {
+        StringWriter sw = new StringWriter()
+        t.printStackTrace(new PrintWriter(sw))
+        return sw.toString()
+    }
+}

--- a/packages/core-api-groovy/src/test/groovy/io/syngrisi/coreapi/AuthHeadersSpec.groovy
+++ b/packages/core-api-groovy/src/test/groovy/io/syngrisi/coreapi/AuthHeadersSpec.groovy
@@ -1,0 +1,120 @@
+package io.syngrisi.coreapi
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpHandler
+import com.sun.net.httpserver.HttpServer
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+/**
+ * Ports tests/SyngrisiApi.auth-headers.test.ts.
+ *
+ * Instead of mocking got, we stand up a real JDK HttpServer on an ephemeral port
+ * that records the last request (method, path, query, headers) and returns staged
+ * JSON ({"results":[]}). SYNGRISI_AUTH_TOKEN is injected via the overridable
+ * authTokenProvider closure (reset between tests).
+ */
+class AuthHeadersSpec extends Specification {
+
+    HttpServer server
+    String baseUrl
+    Map recorded
+
+    def setup() {
+        recorded = [:]
+        server = HttpServer.create(new InetSocketAddress('127.0.0.1', 0), 0)
+        server.createContext('/', new HttpHandler() {
+            @Override
+            void handle(HttpExchange exchange) throws IOException {
+                recorded.method = exchange.requestMethod
+                recorded.path = exchange.requestURI.path
+                recorded.query = exchange.requestURI.query
+                Map<String, String> headers = [:]
+                exchange.requestHeaders.each { k, v -> headers[k] = v ? v[0] : null }
+                recorded.headers = headers
+
+                byte[] body = '{"results":[]}'.getBytes(StandardCharsets.UTF_8)
+                exchange.sendResponseHeaders(200, body.length)
+                exchange.responseBody.withCloseable { it.write(body) }
+            }
+        })
+        server.start()
+        baseUrl = "http://127.0.0.1:${server.address.port}/".toString()
+    }
+
+    def cleanup() {
+        server?.stop(0)
+    }
+
+    private SyngrisiApi makeApi(Map cfg, String envToken = null) {
+        def api = new SyngrisiApi(cfg)
+        // Reset / inject the SYNGRISI_AUTH_TOKEN source per test.
+        api.authTokenProvider = { -> envToken }
+        return api
+    }
+
+    /** A request header is case-insensitive in HttpExchange; helper to look it up. */
+    private String header(String name) {
+        def entry = recorded.headers.find { k, v -> k.equalsIgnoreCase(name) }
+        return entry?.value
+    }
+
+    def "passes custom headers to getBaselines"() {
+        given:
+        def api = makeApi([
+                url    : baseUrl,
+                apiKey : 'plain-api-key',
+                headers: ['X-Kanopy-Authorization': 'Bearer token'],
+        ])
+
+        when:
+        api.getBaselines([
+                name       : 'baseline',
+                viewport   : '1200x800',
+                browserName: 'chrome',
+                os         : 'linux',
+                app        : 'app',
+                branch     : 'main',
+        ])
+
+        then:
+        header('X-Kanopy-Authorization') == 'Bearer token'
+    }
+
+    def "adds Authorization from SYNGRISI_AUTH_TOKEN fallback for getSnapshots"() {
+        given:
+        def api = makeApi([url: baseUrl, apiKey: 'plain-api-key'], 'env-token')
+
+        when:
+        api.getSnapshots([_id: '0123456789abcdef01234567'])
+
+        then:
+        header('Authorization') == 'Bearer env-token'
+    }
+
+    def "does not send apikey in URL or headers when apiKey is omitted"() {
+        given:
+        def api = makeApi([
+                url    : baseUrl,
+                headers: ['Authorization': 'Bearer token'],
+        ])
+
+        when:
+        api.getBaselines([
+                name       : 'baseline',
+                viewport   : '1200x800',
+                browserName: 'chrome',
+                os         : 'linux',
+                app        : 'app',
+                branch     : 'main',
+        ])
+
+        then:
+        recorded.path == '/v1/client/baselines'
+        recorded.query?.startsWith('filter=')
+        !recorded.query.contains('apikey=')
+        header('apikey') == null
+        header('Authorization') == 'Bearer token'
+    }
+}

--- a/packages/core-api-groovy/src/test/groovy/io/syngrisi/coreapi/FunctionalitySpec.groovy
+++ b/packages/core-api-groovy/src/test/groovy/io/syngrisi/coreapi/FunctionalitySpec.groovy
@@ -1,0 +1,249 @@
+package io.syngrisi.coreapi
+
+import spock.lang.Specification
+
+/**
+ * Coverage beyond the JS tests, verifying parity of the remaining functionality:
+ * compression round-trip, two-phase coreCheck, requestWithRetry, accept/update guards.
+ */
+class FunctionalitySpec extends Specification {
+
+    private static Map domNode(String tag, int n = 0) {
+        // builds a DomNode-ish tree; n children to control size
+        return [
+                tagName       : tag,
+                attributes    : [id: 'x'],
+                rect          : [x: 0, y: 0, width: 10, height: 10],
+                computedStyles: [display: 'block'],
+                children      : (0..<n).collect { domNode('span', 0) },
+                text          : 'hello',
+        ]
+    }
+
+    private SyngrisiApi fastApi(Map cfg = [url: 'http://localhost:3000/', apiKey: 'k']) {
+        def api = new SyngrisiApi(cfg)
+        api.retryDelayMs = 0
+        return api
+    }
+
+    def "compression: small dump returned unchanged, not compressed"() {
+        given:
+        def small = domNode('div', 1)
+
+        when:
+        def result = Compression.compressDomDump(small)
+
+        then:
+        result instanceof String
+        !Compression.isCompressedDomDump(result)
+    }
+
+    def "compression: large dump is compressed and round-trips"() {
+        given:
+        // Build a tree well over the 50KB threshold.
+        def big = domNode('div', 4000)
+
+        when:
+        def compressed = Compression.compressDomDump(big)
+
+        then:
+        Compression.isCompressedDomDump(compressed)
+        compressed.compressed == true
+        compressed.originalSize > Compression.DOM_DUMP_COMPRESSION_THRESHOLD
+
+        when:
+        def restored = Compression.decompressDomDump(compressed)
+
+        then:
+        restored == big
+    }
+
+    def "compression: prepareDomDumpForTransfer flags"() {
+        expect:
+        Compression.prepareDomDumpForTransfer(domNode('div', 1)).isCompressed == false
+        Compression.prepareDomDumpForTransfer(domNode('div', 4000)).isCompressed == true
+    }
+
+    def "compression: isCompressedDomDump true/false"() {
+        expect:
+        Compression.isCompressedDomDump([data: 'abc', compressed: true, originalSize: 10])
+        !Compression.isCompressedDomDump([data: 'abc', compressed: false])
+        !Compression.isCompressedDomDump('plain')
+        !Compression.isCompressedDomDump(null)
+    }
+
+    private Map validCheckParams() {
+        return [
+                name              : 'homepage',
+                viewport          : '1200x800',
+                browserName       : 'chrome',
+                os                : 'macOS',
+                app               : 'MyProject',
+                branch            : 'master',
+                testId            : '0123456789abcdef01234567',
+                suite             : 'suite',
+                browserVersion    : '89',
+                browserFullVersion: '89.0.4389.82',
+                hashCode          : 'a' * 64,
+        ]
+    }
+
+    def "two-phase coreCheck: file sent only on phase 2"() {
+        given:
+        def api = fastApi()
+        def calls = []
+        def responses = [[status: 'requiredFileData'], [status: 'new', _id: 'abc']]
+        api.requestExecutor = { Map req ->
+            calls << req
+            return responses[calls.size() - 1]
+        }
+
+        when:
+        def result = api.coreCheck('IMAGE'.bytes, validCheckParams())
+
+        then:
+        calls.size() == 2
+        // phase 1: no file field
+        !calls[0].multipart.any { it.name == 'file' }
+        calls[0].multipart.any { it.name == 'hashcode' }
+        // phase 2: file present
+        calls[1].multipart.any { it.name == 'file' && it.bytes != null }
+        result.status == 'new'
+    }
+
+    def "coreCheck returns phase 1 result when not requiredFileData"() {
+        given:
+        def api = fastApi()
+        def calls = []
+        api.requestExecutor = { Map req ->
+            calls << req
+            return [status: 'passed', _id: 'id1']
+        }
+
+        when:
+        def result = api.coreCheck('IMG'.bytes, validCheckParams())
+
+        then:
+        calls.size() == 1
+        result.status == 'passed'
+    }
+
+    def "addMessageIfCheckFailed wires links on failed status"() {
+        given:
+        def api = fastApi()
+        api.requestExecutor = { Map req -> [status: 'failed', _id: 'CID'] }
+
+        when:
+        def result = api.coreCheck('IMG'.bytes, validCheckParams())
+
+        then:
+        result.status == 'failed'
+        result.vrsGroupLink == "'http://localhost:3000/?checkId=CID&modalIsOpen=true'"
+        result.vrsDiffLink == result.vrsGroupLink
+        result.message.contains('follow the link')
+    }
+
+    def "requestWithRetry: 401 then 200 eventually succeeds"() {
+        given:
+        def api = fastApi([url: 'http://localhost:3000/'])
+        int attempts = 0
+        api.requestExecutor = { Map req ->
+            attempts++
+            if (attempts == 1) {
+                throw new HttpError(401, 'Unauthorized', 'nope')
+            }
+            return ['ident-a', 'ident-b']
+        }
+
+        when:
+        def result = api.getIdent()
+
+        then:
+        attempts == 2
+        result == ['ident-a', 'ident-b']
+    }
+
+    def "requestWithRetry: non-401 error returns errorObject without retry"() {
+        given:
+        def api = fastApi([url: 'http://localhost:3000/'])
+        int attempts = 0
+        api.requestExecutor = { Map req ->
+            attempts++
+            throw new HttpError(500, 'Internal Server Error', 'boom')
+        }
+
+        when:
+        def result = api.getIdent()
+
+        then:
+        attempts == 1
+        result.error == true
+        result.statusCode == 500
+    }
+
+    def "requestWithRetry: 401 on all attempts returns errorObject after maxRetries"() {
+        given:
+        def api = fastApi([url: 'http://localhost:3000/'])
+        int attempts = 0
+        api.requestExecutor = { Map req ->
+            attempts++
+            throw new HttpError(401, 'Unauthorized', 'nope')
+        }
+
+        when:
+        def result = api.getIdent()
+
+        then:
+        attempts == 3
+        result.error == true
+        result.statusCode == 401
+    }
+
+    def "acceptCheck guards: missing ids return errorObject without HTTP call"() {
+        given:
+        def api = fastApi()
+        boolean called = false
+        api.requestExecutor = { Map req -> called = true; [:] }
+
+        expect:
+        api.acceptCheck(null, 'b').error == true
+        api.acceptCheck('c', null).error == true
+        !called
+    }
+
+    def "updateBaseline guard: missing baselineId returns errorObject without HTTP call"() {
+        given:
+        def api = fastApi()
+        boolean called = false
+        api.requestExecutor = { Map req -> called = true; [:] }
+
+        expect:
+        api.updateBaseline(null, [ignoreRegions: '[]']).error == true
+        !called
+    }
+
+    def "acceptCheck happy path sends PUT json"() {
+        given:
+        def api = fastApi()
+        Map captured = null
+        api.requestExecutor = { Map req -> captured = req; [ok: true] }
+
+        when:
+        def result = api.acceptCheck('CHK', 'BASE')
+
+        then:
+        captured.method == 'PUT'
+        captured.url == 'http://localhost:3000/v1/checks/CHK/accept'
+        captured.json == [baselineId: 'BASE']
+        result.ok == true
+    }
+
+    def "DOM collector script constant + accessor"() {
+        expect:
+        DomCollector.COLLECT_DOM_TREE_SCRIPT.contains('function collectDomTree()')
+        DomCollector.COLLECT_DOM_TREE_SCRIPT.contains('return collectDomTree();')
+        DomCollector.getCollectDomTreeScript() == DomCollector.COLLECT_DOM_TREE_SCRIPT
+        Schemas.STYLES_TO_CAPTURE.contains('boxShadow')
+        Schemas.DOM_DUMP_COMPRESSION_THRESHOLD == 50 * 1024
+    }
+}

--- a/packages/core-api-groovy/src/test/groovy/io/syngrisi/coreapi/SyngrisiApiSpec.groovy
+++ b/packages/core-api-groovy/src/test/groovy/io/syngrisi/coreapi/SyngrisiApiSpec.groovy
@@ -1,0 +1,44 @@
+package io.syngrisi.coreapi
+
+import spock.lang.Specification
+
+/** Ports tests/SyngrisiApi.test.ts — constructor + transformOs. */
+class SyngrisiApiSpec extends Specification {
+
+    def "should create instance with valid config"() {
+        when:
+        def api = new SyngrisiApi([url: 'http://localhost:3000/', apiKey: 'test-api-key'])
+
+        then:
+        api instanceof SyngrisiApi
+    }
+
+    def "should throw error with invalid config (missing url)"() {
+        when:
+        new SyngrisiApi([apiKey: 'test'])
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "should create instance without apiKey (optional)"() {
+        when:
+        def api = new SyngrisiApi([url: 'http://localhost:3000/'])
+
+        then:
+        api instanceof SyngrisiApi
+    }
+
+    def "transformOs maps platforms correctly"() {
+        expect:
+        Utils.transformOs(input) == expected
+
+        where:
+        input        | expected
+        'UnknownOS'  | 'UnknownOS'
+        'macintel'   | 'macOS'
+        'win32'      | 'WINDOWS'
+        'linux'      | 'linux'
+        'darwin'     | 'darwin'
+    }
+}

--- a/packages/core-api-python/.gitignore
+++ b/packages/core-api-python/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+*.egg-info/
+.coverage
+dist/
+build/

--- a/packages/core-api-python/README.md
+++ b/packages/core-api-python/README.md
@@ -1,0 +1,76 @@
+# syngrisi-core-api (Python)
+
+Python port of the Syngrisi `@syngrisi/core-api` JS package, with full
+functional parity. SDK version: **3.6.0**.
+
+## Install
+
+```bash
+python3 -m venv .venv
+.venv/bin/pip install -e .            # runtime (requests)
+.venv/bin/pip install -e ".[dev]"     # + test deps (responses, pytest)
+```
+
+## Usage
+
+```python
+from syngrisi_core_api import SyngrisiApi, transform_os
+
+api = SyngrisiApi({"url": "http://localhost:3000/", "apiKey": "your-api-key"})
+
+session = api.start_session({
+    "run": "run-id",
+    "suite": "suite-name",
+    "runident": "run-identifier",
+    "name": "test-name",
+    "viewport": "1200x800",
+    "browser": "chrome",
+    "browserVersion": "113",
+    "browserFullVersion": "113.0.0.0",
+    "os": "macOS",
+    "app": "MyProject",
+    "branch": "main",
+})
+
+result = api.core_check(image_bytes, {
+    "name": "homepage",
+    "viewport": "1200x800",
+    "browserName": "chrome",
+    "os": "macOS",
+    "app": "MyProject",
+    "branch": "main",
+    "testId": session["testId"],
+    "suite": "suite-name",
+    "browserVersion": "113",
+    "browserFullVersion": "113.0.0.0",
+    "hashCode": "<64+ char hash>",
+})
+
+api.stop_session(session["testId"])
+```
+
+Method names are Pythonic (`start_session`, `core_check`, `get_baselines`,
+`transform_os`, ...) but the JS-style camelCase names are also exposed as
+aliases (`startSession`, `coreCheck`, `getBaselines`, `transformOs`, ...).
+Wire behaviour (field names, URL shapes, header names) is identical to the JS
+package.
+
+## Public surface
+
+- `SyngrisiApi` — constructor, `start_session`, `stop_session`, `core_check`,
+  `get_ident`, `get_baselines`, `get_snapshots`, `accept_check`,
+  `update_baseline`.
+- `transform_os`, `error_object`.
+- Compression: `is_compressed_dom_dump`, `compress_dom_dump`,
+  `decompress_dom_dump`, `prepare_dom_dump_for_transfer`.
+- `COLLECT_DOM_TREE_SCRIPT`, `get_collect_dom_tree_script`.
+- `STYLES_TO_CAPTURE`, `DOM_DUMP_COMPRESSION_THRESHOLD`.
+
+Validation throws (`ValidationError`) on invalid params; HTTP methods return an
+error dict (`{"error": True, ...}`) instead of raising.
+
+## Tests
+
+```bash
+.venv/bin/pytest -q
+```

--- a/packages/core-api-python/pyproject.toml
+++ b/packages/core-api-python/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "syngrisi-core-api"
+version = "3.6.0"
+description = "Syngrisi Core API — Python client for the Syngrisi Visual Testing Platform"
+readme = "README.md"
+requires-python = ">=3.8"
+license = { text = "MIT" }
+authors = [{ name = "Viktar Silakou" }]
+keywords = ["visual", "regression", "test", "SDK"]
+dependencies = ["requests>=2.25"]
+
+[project.optional-dependencies]
+dev = ["responses>=0.23", "pytest>=7.0"]
+
+[tool.setuptools.packages.find]
+include = ["syngrisi_core_api*"]

--- a/packages/core-api-python/requirements-dev.txt
+++ b/packages/core-api-python/requirements-dev.txt
@@ -1,0 +1,3 @@
+requests>=2.25
+responses>=0.23
+pytest>=7.0

--- a/packages/core-api-python/syngrisi_core_api/__init__.py
+++ b/packages/core-api-python/syngrisi_core_api/__init__.py
@@ -1,0 +1,51 @@
+"""Python port of the Syngrisi `@syngrisi/core-api` package."""
+
+from .api import SDK_VERSION, SyngrisiApi
+from .compression import (
+    compress_dom_dump,
+    compressDomDump,
+    decompress_dom_dump,
+    decompressDomDump,
+    is_compressed_dom_dump,
+    isCompressedDomDump,
+    prepare_dom_dump_for_transfer,
+    prepareDomDumpForTransfer,
+)
+from .dom_collector import (
+    COLLECT_DOM_TREE_SCRIPT,
+    collect_dom_tree,
+    collectDomTree,
+    get_collect_dom_tree_script,
+    getCollectDomTreeScript,
+)
+from .schemas import (
+    DOM_DUMP_COMPRESSION_THRESHOLD,
+    STYLES_TO_CAPTURE,
+    ValidationError,
+)
+from .utils import error_object, errorObject, transform_os, transformOs
+
+__all__ = [
+    "SyngrisiApi",
+    "SDK_VERSION",
+    "transform_os",
+    "transformOs",
+    "error_object",
+    "errorObject",
+    "is_compressed_dom_dump",
+    "isCompressedDomDump",
+    "compress_dom_dump",
+    "compressDomDump",
+    "decompress_dom_dump",
+    "decompressDomDump",
+    "prepare_dom_dump_for_transfer",
+    "prepareDomDumpForTransfer",
+    "COLLECT_DOM_TREE_SCRIPT",
+    "get_collect_dom_tree_script",
+    "getCollectDomTreeScript",
+    "collect_dom_tree",
+    "collectDomTree",
+    "STYLES_TO_CAPTURE",
+    "DOM_DUMP_COMPRESSION_THRESHOLD",
+    "ValidationError",
+]

--- a/packages/core-api-python/syngrisi_core_api/api.py
+++ b/packages/core-api-python/syngrisi_core_api/api.py
@@ -1,0 +1,278 @@
+"""SyngrisiApi client ported from JS `src/SyngrisiApi.ts`."""
+
+import hashlib
+import json
+import os
+import time
+from urllib.parse import quote
+
+import requests
+
+from .compression import prepare_dom_dump_for_transfer
+from .schemas import (
+    validate_api_session_params,
+    validate_baseline_params,
+    validate_check_params,
+    validate_config,
+    validate_snapshot,
+)
+from .utils import error_object, pretty_check_result
+
+# SDK version (matches the JS package.json version).
+SDK_VERSION = "3.6.0"
+
+
+def _hasha(value):
+    """SHA-512 hex digest (matches JS hasha default of SHA-512)."""
+    return hashlib.sha512((value or "").encode("utf-8")).hexdigest()
+
+
+def _is_dom_data_disabled():
+    return os.environ.get("SYNGRISI_DISABLE_DOM_DATA") == "true"
+
+
+class SyngrisiApi:
+    """API client for the Syngrisi visual regression testing service."""
+
+    # Retry configuration (overridable in tests to keep them fast).
+    max_retries = 3
+    retry_delay_ms = 2000
+
+    def __init__(self, cfg):
+        validate_config(cfg, "SyngrisiApi, constructor, cfg")
+        # Store a shallow copy so we can attach the computed apiHash.
+        self.config = dict(cfg)
+        self.config["apiHash"] = _hasha(cfg.get("apiKey") or "")
+
+    # ----- internal helpers -------------------------------------------------
+
+    @property
+    def _headers(self):
+        headers = {"x-syngrisi-sdk-version": SDK_VERSION}
+        headers.update(self.config.get("headers") or {})
+
+        if self.config.get("apiKey"):
+            headers["apikey"] = self.config["apiHash"]
+
+        # Hybrid Auth: fall back to ENV variable if not explicitly set.
+        env_token = os.environ.get("SYNGRISI_AUTH_TOKEN")
+        if "Authorization" not in headers and "authorization" not in headers and env_token:
+            headers["Authorization"] = f"Bearer {env_token}"
+
+        return headers
+
+    def _url(self, item_name):
+        # config.url already ends with '/'.
+        return f"{self.config['url']}v1/client/{item_name}"
+
+    def _request_with_retry(self, request_fn, method_name, error_message):
+        max_retries = self.max_retries
+        retry_delay_ms = self.retry_delay_ms
+
+        for attempt in range(1, max_retries + 1):
+            try:
+                return request_fn()
+            except Exception as e:  # noqa: BLE001 - mirror JS catch-all
+                response = getattr(e, "response", None)
+                is_401 = response is not None and getattr(response, "status_code", None) == 401
+                is_last_attempt = attempt == max_retries
+
+                if is_401 and not is_last_attempt:
+                    time.sleep(retry_delay_ms / 1000.0)
+                    continue
+
+                return error_object(e)
+
+        return error_object(Exception("Max retries exceeded"))
+
+    @staticmethod
+    def _get_json(method, url, **kwargs):
+        resp = requests.request(method, url, **kwargs)
+        resp.raise_for_status()
+        return resp.json()
+
+    # ----- session methods --------------------------------------------------
+
+    def start_session(self, params):
+        validate_api_session_params(params, "startSession, params")
+
+        def do_request():
+            fields = {}
+            for field in ("run", "suite", "runident", "name", "viewport",
+                          "browser", "browserVersion", "os", "app"):
+                fields[field] = (None, str(params[field]))
+            if params.get("tags"):
+                fields["tags"] = (None, json.dumps(params["tags"], separators=(",", ":")))
+            if params.get("branch"):
+                fields["branch"] = (None, str(params["branch"]))
+            return self._get_json("POST", self._url("startSession"),
+                                   files=fields, headers=self._headers)
+
+        return self._request_with_retry(
+            do_request, "startSession", "Error posting start session data"
+        )
+
+    def stop_session(self, test_id):
+        def do_request():
+            url = f"{self._url('stopSession')}/{test_id}"
+            # Empty multipart body.
+            return self._get_json("POST", url, files={"_": (None, "")},
+                                  headers=self._headers)
+
+        return self._request_with_retry(
+            do_request, "stopSession",
+            f"Error posting stop session data for test: '{test_id}'"
+        )
+
+    # ----- check methods ----------------------------------------------------
+
+    def _add_message_if_check_failed(self, result):
+        patched = result
+        if not isinstance(patched, dict):
+            return patched
+        # Skip if result is an error object or status is not a string.
+        if patched.get("error") or not isinstance(patched.get("status"), str):
+            return patched
+        if "failed" in patched["status"]:
+            check_view = f"'{self.config['url']}?checkId={patched.get('_id')}&modalIsOpen=true'"
+            patched["message"] = f"To evaluate the results of the check, follow the link: '{check_view}'"
+            # The links are basically useless - kept for backward compatibility.
+            patched["vrsGroupLink"] = check_view
+            patched["vrsDiffLink"] = check_view
+        return patched
+
+    def core_check(self, image_buffer, params):
+        result_with_hash = self._perform_check(params, None, params.get("hashCode"))
+        result_with_hash = self._add_message_if_check_failed(result_with_hash)
+
+        if isinstance(result_with_hash, dict) and result_with_hash.get("status") == "requiredFileData":
+            result_with_file = self._perform_check(params, image_buffer, params.get("hashCode"))
+            result_with_file = self._add_message_if_check_failed(result_with_file)
+            return result_with_file
+        return result_with_hash
+
+    _FIELDS_MAPPING = {
+        "branch": "branch",
+        "app": "appName",
+        "suite": "suitename",
+        "vShifting": "vShifting",
+        "testId": "testid",
+        "name": "name",
+        "viewport": "viewport",
+        "browserName": "browserName",
+        "browserVersion": "browserVersion",
+        "browserFullVersion": "browserFullVersion",
+        "os": "os",
+        "toleranceThreshold": "toleranceThreshold",
+    }
+
+    def _perform_check(self, params, image_buffer, hash_code):
+        validate_check_params(params, "createCheck, params")
+        url = self._url("createCheck")
+
+        def do_request():
+            fields = []
+            request_headers = dict(self._headers)
+
+            for key, mapped in self._FIELDS_MAPPING.items():
+                value = params.get(key)
+                if value is not None:
+                    fields.append((mapped, (None, str(value))))
+
+            # Handle domDump with compression for RCA.
+            should_skip_dom = _is_dom_data_disabled() or params.get("skipDomData") is True
+            if params.get("domDump") and not should_skip_dom:
+                prepared = prepare_dom_dump_for_transfer(params["domDump"])
+                fields.append(("domdump", (None, prepared["data"])))
+                if prepared["isCompressed"]:
+                    request_headers["x-domdump-compressed"] = "gzip"
+
+            if hash_code:
+                fields.append(("hashcode", (None, hash_code)))
+            if image_buffer is not None:
+                fields.append(("file", ("file", image_buffer)))
+
+            return self._get_json("POST", url, files=fields, headers=request_headers)
+
+        return self._request_with_retry(
+            do_request, "createCheck",
+            f"Error posting create check data params: '{json.dumps(params, default=str)}'"
+        )
+
+    # ----- read methods -----------------------------------------------------
+
+    def get_ident(self):
+        if self.config.get("apiKey"):
+            url = f"{self._url('getIdent')}?apikey={self.config['apiHash']}"
+        else:
+            url = self._url("getIdent")
+        return self._request_with_retry(
+            lambda: self._get_json("GET", url, headers=self._headers),
+            "getIdent", "Error getting ident data"
+        )
+
+    def get_baselines(self, params):
+        validate_baseline_params(params, "getBaselines, params")
+        filter_ = quote(json.dumps(params, separators=(",", ":")), safe="")
+        if self.config.get("apiKey"):
+            url = f"{self._url('baselines')}?filter={filter_}&apikey={self.config['apiHash']}"
+        else:
+            url = f"{self._url('baselines')}?filter={filter_}"
+        return self._request_with_retry(
+            lambda: self._get_json("GET", url, headers=self._headers),
+            "getBaselines",
+            f"Error getting baselines, params: '{json.dumps(params, default=str)}' data"
+        )
+
+    def get_snapshots(self, params):
+        validate_snapshot(params, "getSnapshots, params")
+        filter_ = quote(json.dumps(params, separators=(",", ":")), safe="")
+        if self.config.get("apiKey"):
+            url = f"{self._url('snapshots')}?filter={filter_}&apikey={self.config['apiHash']}"
+        else:
+            url = f"{self._url('snapshots')}?filter={filter_}"
+        return self._request_with_retry(
+            lambda: self._get_json("GET", url, headers=self._headers),
+            "getSnapshots",
+            f"Error getting snapshots, params: '{json.dumps(params, default=str)}' data"
+        )
+
+    def accept_check(self, check_id, baseline_id):
+        if not check_id:
+            return error_object(Exception("checkId is required"))
+        if not baseline_id:
+            return error_object(Exception("baselineId is required"))
+
+        def do_request():
+            url = f"{self.config['url']}v1/checks/{check_id}/accept"
+            return self._get_json("PUT", url, json={"baselineId": baseline_id},
+                                  headers=self._headers)
+
+        return self._request_with_retry(
+            do_request, "acceptCheck",
+            f"Error accepting check, checkId: '{check_id}', baselineId: '{baseline_id}'"
+        )
+
+    def update_baseline(self, baseline_id, updates):
+        if not baseline_id:
+            return error_object(Exception("baselineId is required"))
+
+        url = f"{self.config['url']}v1/baselines/{baseline_id}"
+
+        def do_request():
+            return self._get_json("PUT", url, json=updates, headers=self._headers)
+
+        return self._request_with_retry(
+            do_request, "updateBaseline",
+            f"Error updating baseline, baselineId: '{baseline_id}', updates: '{json.dumps(updates, default=str)}'"
+        )
+
+    # ----- JS-style aliases -------------------------------------------------
+    startSession = start_session
+    stopSession = stop_session
+    coreCheck = core_check
+    getIdent = get_ident
+    getBaselines = get_baselines
+    getSnapshots = get_snapshots
+    acceptCheck = accept_check
+    updateBaseline = update_baseline

--- a/packages/core-api-python/syngrisi_core_api/compression.py
+++ b/packages/core-api-python/syngrisi_core_api/compression.py
@@ -1,0 +1,100 @@
+"""DOM dump compression utilities ported from JS `src/compression.ts`.
+
+Uses gzip + base64. The compression threshold is 50KB (DOM_DUMP_COMPRESSION_THRESHOLD).
+"""
+
+import base64
+import gzip
+import json
+
+from .schemas import DOM_DUMP_COMPRESSION_THRESHOLD
+
+
+def _json_stringify(value):
+    """Equivalent of JS JSON.stringify (compact, no extra whitespace)."""
+    return json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+
+
+def is_compressed_dom_dump(data):
+    """True iff ``data`` is a dict with ``compressed == True`` and a string ``data``."""
+    return (
+        isinstance(data, dict)
+        and data.get("compressed") is True
+        and isinstance(data.get("data"), str)
+    )
+
+
+def compress_dom_dump(dom_dump):
+    """Compress a DOM dump if it exceeds the threshold.
+
+    Returns the original JSON string when below the threshold, otherwise a
+    ``{data, compressed: True, originalSize}`` dict.
+    """
+    json_string = dom_dump if isinstance(dom_dump, str) else _json_stringify(dom_dump)
+
+    original_size = len(json_string.encode("utf-8"))
+
+    # Skip compression for small payloads.
+    if original_size <= DOM_DUMP_COMPRESSION_THRESHOLD:
+        return json_string
+
+    compressed = gzip.compress(json_string.encode("utf-8"))
+
+    return {
+        "data": base64.b64encode(compressed).decode("ascii"),
+        "compressed": True,
+        "originalSize": original_size,
+    }
+
+
+def decompress_dom_dump(data):
+    """Decompress a DOM dump, handling compressed/uncompressed/string formats.
+
+    Returns the parsed DomNode object or ``None`` if invalid.
+    """
+    try:
+        # Already a DomNode object (dict, not compressed).
+        if isinstance(data, dict) and not is_compressed_dom_dump(data):
+            return data
+
+        # Compressed format.
+        if is_compressed_dom_dump(data):
+            buffer = base64.b64decode(data["data"])
+            decompressed = gzip.decompress(buffer).decode("utf-8")
+            return json.loads(decompressed)
+
+        # JSON string.
+        if isinstance(data, str):
+            parsed = json.loads(data)
+            if is_compressed_dom_dump(parsed):
+                return decompress_dom_dump(parsed)
+            return parsed
+
+        return None
+    except Exception as e:  # noqa: BLE001 - mirror JS catch-all
+        print(f"Failed to decompress domDump: {e}")
+        return None
+
+
+def prepare_dom_dump_for_transfer(dom_dump):
+    """Prepare a DOM dump for transfer.
+
+    Returns ``{"data": str, "isCompressed": bool}``.
+    """
+    # If already compressed, just stringify it.
+    if is_compressed_dom_dump(dom_dump):
+        return {"data": _json_stringify(dom_dump), "isCompressed": True}
+
+    result = compress_dom_dump(dom_dump)
+
+    if is_compressed_dom_dump(result):
+        return {"data": _json_stringify(result), "isCompressed": True}
+
+    return {"data": result, "isCompressed": False}
+
+
+# JS-style aliases.
+isCompressedDomDump = is_compressed_dom_dump
+compressDomDump = compress_dom_dump
+decompressDomDump = decompress_dom_dump
+prepareDomDumpForTransfer = prepare_dom_dump_for_transfer

--- a/packages/core-api-python/syngrisi_core_api/dom_collector.py
+++ b/packages/core-api-python/syngrisi_core_api/dom_collector.py
@@ -1,0 +1,122 @@
+"""DOM collector script ported from JS `src/domCollector.ts`.
+
+The runtime ``collectDomTree`` function is browser-only; for Python parity we
+expose the injectable script string constant and an accessor. The script body
+mirrors the JS source.
+"""
+
+# Browser-injectable DOM collection script. Mirrors the JS COLLECT_DOM_TREE_SCRIPT,
+# which wraps `collectDomTree.toString()` in a self-invoking function.
+COLLECT_DOM_TREE_SCRIPT = r"""
+(function() {
+    function collectDomTree() {
+        function isVisible(el) {
+            const style = window.getComputedStyle(el);
+            if (style.display === 'none' ||
+                style.visibility === 'hidden' ||
+                parseFloat(style.opacity) === 0) {
+                return false;
+            }
+            const rect = el.getBoundingClientRect();
+            return rect.width > 0 && rect.height > 0;
+        }
+        function getAttributes(el) {
+            const attrs = {};
+            for (const attr of Array.from(el.attributes)) {
+                if (!attr.name.startsWith('data-') || attr.name === 'data-testid') {
+                    attrs[attr.name] = attr.value;
+                }
+            }
+            return attrs;
+        }
+        function getComputedStyles(el) {
+            const computed = window.getComputedStyle(el);
+            const styles = {};
+            const stylesToCapture = [
+                'display', 'visibility', 'opacity',
+                'position', 'top', 'right', 'bottom', 'left',
+                'width', 'height', 'min-width', 'min-height', 'max-width', 'max-height',
+                'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left',
+                'padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left',
+                'border', 'border-width', 'border-style', 'border-color',
+                'border-radius',
+                'background-color', 'color',
+                'font-family', 'font-size', 'font-weight', 'line-height', 'text-align',
+                'text-decoration', 'text-transform', 'letter-spacing',
+                'overflow', 'overflow-x', 'overflow-y',
+                'z-index',
+                'transform',
+                'flex', 'flex-direction', 'flex-wrap', 'justify-content', 'align-items', 'align-content', 'gap',
+                'grid-template-columns', 'grid-template-rows', 'grid-gap',
+                'box-shadow'
+            ];
+            for (const prop of stylesToCapture) {
+                const value = computed.getPropertyValue(prop);
+                if (value && value !== 'initial' && value !== 'none' && value !== 'normal' && value !== 'auto' && value !== '0px' && value !== 'rgba(0, 0, 0, 0)') {
+                    const camelProp = prop.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+                    styles[camelProp] = value;
+                }
+            }
+            return styles;
+        }
+        function getDirectText(el) {
+            let text = '';
+            for (const child of Array.from(el.childNodes)) {
+                if (child.nodeType === Node.TEXT_NODE) {
+                    text += child.textContent?.trim() || '';
+                }
+            }
+            const trimmed = text.trim();
+            if (!trimmed) return undefined;
+            return trimmed.length > 200 ? trimmed.substring(0, 200) + '...' : trimmed;
+        }
+        function collectNode(el, depth = 0) {
+            if (depth > 15) return null;
+            if (!isVisible(el)) return null;
+            const skipTags = ['SCRIPT', 'STYLE', 'NOSCRIPT', 'META', 'LINK', 'HEAD', 'SVG', 'PATH'];
+            if (skipTags.includes(el.tagName)) return null;
+            const rect = el.getBoundingClientRect();
+            const children = [];
+            for (const child of Array.from(el.children)) {
+                const childNode = collectNode(child, depth + 1);
+                if (childNode) {
+                    children.push(childNode);
+                }
+            }
+            return {
+                tagName: el.tagName.toLowerCase(),
+                attributes: getAttributes(el),
+                rect: {
+                    x: Math.round(rect.x),
+                    y: Math.round(rect.y),
+                    width: Math.round(rect.width),
+                    height: Math.round(rect.height)
+                },
+                computedStyles: getComputedStyles(el),
+                children,
+                text: getDirectText(el)
+            };
+        }
+        const root = collectNode(document.body);
+        return JSON.stringify(root);
+    }
+    return collectDomTree();
+})()
+"""
+
+
+def get_collect_dom_tree_script():
+    """Return the injectable DOM collection script string."""
+    return COLLECT_DOM_TREE_SCRIPT
+
+
+def collect_dom_tree(*args, **kwargs):
+    """Browser-only runtime function. Not available outside a browser context."""
+    raise NotImplementedError(
+        "collect_dom_tree runs only in a browser context; inject COLLECT_DOM_TREE_SCRIPT instead."
+    )
+
+
+# JS-style aliases.
+getCollectDomTreeScript = get_collect_dom_tree_script
+collectDomTree = collect_dom_tree

--- a/packages/core-api-python/syngrisi_core_api/schemas.py
+++ b/packages/core-api-python/syngrisi_core_api/schemas.py
@@ -1,0 +1,229 @@
+"""Schemas / validation rules ported from the JS zod schemas.
+
+Validation is implemented manually (no heavy dependency). Each guard raises
+``ValidationError`` (a subclass of ``ValueError``) with a clear message when a
+rule fails, mirroring zod's "throw on invalid" behaviour.
+"""
+
+import re
+
+# Compression threshold in bytes (50KB). DOM dumps larger than this are compressed.
+DOM_DUMP_COMPRESSION_THRESHOLD = 50 * 1024
+
+# CSS properties to capture for RCA analysis (camelCase, mirrors JS STYLES_TO_CAPTURE).
+STYLES_TO_CAPTURE = [
+    # Display & Visibility
+    "display", "visibility", "opacity",
+    # Position
+    "position", "top", "right", "bottom", "left",
+    # Dimensions
+    "width", "height", "minWidth", "minHeight", "maxWidth", "maxHeight",
+    # Box Model
+    "margin", "marginTop", "marginRight", "marginBottom", "marginLeft",
+    "padding", "paddingTop", "paddingRight", "paddingBottom", "paddingLeft",
+    "border", "borderWidth", "borderStyle", "borderColor",
+    "borderRadius",
+    # Colors
+    "backgroundColor", "color",
+    # Typography
+    "fontFamily", "fontSize", "fontWeight", "lineHeight", "textAlign",
+    "textDecoration", "textTransform", "letterSpacing",
+    # Layout
+    "overflow", "overflowX", "overflowY",
+    "zIndex",
+    "transform",
+    # Flexbox
+    "flex", "flexDirection", "flexWrap", "justifyContent", "alignItems", "alignContent", "gap",
+    # Grid
+    "gridTemplateColumns", "gridTemplateRows", "gridGap",
+    # Box Shadow
+    "boxShadow",
+]
+
+_VIEWPORT_RE = re.compile(r"^\d+x\d+$")
+
+
+class ValidationError(ValueError):
+    """Raised when parameter validation fails (mirrors zod throwing on invalid)."""
+
+
+def _fail(function_name, errors, params):
+    raise ValidationError(
+        "Invalid '{fn}' parameters:\n{errs}\n params: {params}".format(
+            fn=function_name,
+            errs="\n".join(errors),
+            params=params,
+        )
+    )
+
+
+def _is_str(value):
+    return isinstance(value, str)
+
+
+def _is_number(value):
+    # bool is a subclass of int in Python; exclude it to match JS number semantics.
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _check_viewport(value, field, errors):
+    if not _is_str(value):
+        errors.append(f"{field}: expected string")
+        return
+    if len(value) < 3 or not _VIEWPORT_RE.match(value):
+        errors.append(f"{field}: invalid viewport format (expected '<width>x<height>')")
+
+
+def _check_non_empty_str(value, field, errors):
+    if not _is_str(value):
+        errors.append(f"{field}: expected string")
+    elif len(value) < 1:
+        errors.append(f"{field}: must be a non-empty string")
+
+
+def _check_str(value, field, errors):
+    if not _is_str(value):
+        errors.append(f"{field}: expected string")
+
+
+def _check_id_string(value, field, errors):
+    if not _is_str(value):
+        errors.append(f"{field}: expected string")
+    elif len(value) != 24:
+        errors.append(f"{field}: expected string of length 24")
+
+
+def _check_str_or_number_nonempty(value, field, errors):
+    if _is_number(value):
+        return
+    if _is_str(value):
+        if len(value) < 1:
+            errors.append(f"{field}: must be a non-empty string")
+        return
+    errors.append(f"{field}: expected non-empty string or number")
+
+
+def validate_config(params, function_name="SyngrisiApi, constructor, cfg"):
+    """ConfigSchema: url non-empty str; apiKey optional str; headers optional map<str,str>."""
+    errors = []
+    if not isinstance(params, dict):
+        _fail(function_name, ["expected an object"], params)
+
+    _check_non_empty_str(params.get("url"), "url", errors)
+
+    if "apiKey" in params and params.get("apiKey") is not None:
+        _check_str(params.get("apiKey"), "apiKey", errors)
+
+    headers = params.get("headers")
+    if "headers" in params and headers is not None:
+        if not isinstance(headers, dict):
+            errors.append("headers: expected a map")
+        else:
+            for k, v in headers.items():
+                if not _is_str(k) or not _is_str(v):
+                    errors.append("headers: expected map<string, string>")
+                    break
+
+    if errors:
+        _fail(function_name, errors, params)
+    return True
+
+
+def validate_api_session_params(params, function_name="startSession, params"):
+    errors = []
+    if not isinstance(params, dict):
+        _fail(function_name, ["expected an object"], params)
+
+    for field in ("run", "suite", "runident", "name"):
+        _check_non_empty_str(params.get(field), field, errors)
+    _check_viewport(params.get("viewport"), "viewport", errors)
+    _check_non_empty_str(params.get("browser"), "browser", errors)
+    _check_str_or_number_nonempty(params.get("browserVersion"), "browserVersion", errors)
+    _check_non_empty_str(params.get("browserFullVersion"), "browserFullVersion", errors)
+    _check_str(params.get("os"), "os", errors)
+    _check_str(params.get("app"), "app", errors)
+
+    tags = params.get("tags")
+    if "tags" in params and tags is not None:
+        if not isinstance(tags, list) or not all(_is_str(t) for t in tags):
+            errors.append("tags: expected array of strings")
+
+    _check_str(params.get("branch"), "branch", errors)
+
+    if errors:
+        _fail(function_name, errors, params)
+    return True
+
+
+def validate_check_params(params, function_name="createCheck, params"):
+    errors = []
+    if not isinstance(params, dict):
+        _fail(function_name, ["expected an object"], params)
+
+    for field in ("name", "browserName", "os", "app", "branch"):
+        _check_non_empty_str(params.get(field), field, errors)
+    _check_viewport(params.get("viewport"), "viewport", errors)
+    _check_id_string(params.get("testId"), "testId", errors)
+    _check_non_empty_str(params.get("suite"), "suite", errors)
+    _check_str_or_number_nonempty(params.get("browserVersion"), "browserVersion", errors)
+    _check_non_empty_str(params.get("browserFullVersion"), "browserFullVersion", errors)
+
+    hash_code = params.get("hashCode")
+    if not _is_str(hash_code):
+        errors.append("hashCode: expected string")
+    elif len(hash_code) < 64:
+        errors.append("hashCode: must be at least 64 characters")
+
+    skip_dom = params.get("skipDomData")
+    if "skipDomData" in params and skip_dom is not None and not isinstance(skip_dom, bool):
+        errors.append("skipDomData: expected boolean")
+
+    tol = params.get("toleranceThreshold")
+    if "toleranceThreshold" in params and tol is not None:
+        if not _is_number(tol):
+            errors.append("toleranceThreshold: expected number")
+        elif tol < 0 or tol > 100:
+            errors.append("toleranceThreshold: must be between 0 and 100")
+
+    if errors:
+        _fail(function_name, errors, params)
+    return True
+
+
+def validate_baseline_params(params, function_name="getBaselines, params"):
+    errors = []
+    if not isinstance(params, dict):
+        _fail(function_name, ["expected an object"], params)
+
+    for field in ("name", "browserName", "os", "app", "branch"):
+        _check_non_empty_str(params.get(field), field, errors)
+    _check_viewport(params.get("viewport"), "viewport", errors)
+
+    if errors:
+        _fail(function_name, errors, params)
+    return True
+
+
+def validate_snapshot(params, function_name="getSnapshots, params"):
+    """Snapshot: all fields optional. _id len24, name/filename non-empty, imghash len128."""
+    errors = []
+    if not isinstance(params, dict):
+        _fail(function_name, ["expected an object"], params)
+
+    if params.get("_id") is not None:
+        _check_id_string(params.get("_id"), "_id", errors)
+    if params.get("name") is not None:
+        _check_non_empty_str(params.get("name"), "name", errors)
+    if params.get("filename") is not None:
+        _check_non_empty_str(params.get("filename"), "filename", errors)
+    if params.get("imghash") is not None:
+        v = params.get("imghash")
+        if not _is_str(v):
+            errors.append("imghash: expected string")
+        elif len(v) != 128:
+            errors.append("imghash: expected string of length 128")
+    # createdDate is optional; no strict type check needed for transfer.
+
+    if errors:
+        _fail(function_name, errors, params)
+    return True

--- a/packages/core-api-python/syngrisi_core_api/utils.py
+++ b/packages/core-api-python/syngrisi_core_api/utils.py
@@ -1,0 +1,60 @@
+"""Utility functions ported from JS `src/utils.ts`."""
+
+import json
+
+# Mapping of normalized OS names (keys are lowercase platform identifiers).
+_OS_TRANSFORM = {
+    "win32": "WINDOWS",
+    "windows": "WINDOWS",
+    "macintel": "macOS",
+    "mac os": "macOS",
+}
+
+
+def transform_os(platform):
+    """Transform a platform string to a standardized OS name.
+
+    Lowercases the input and looks it up in the transform map; returns the
+    original input when no match is found.
+    """
+    return _OS_TRANSFORM.get(platform.lower(), platform)
+
+
+# JS-style alias.
+transformOs = transform_os
+
+
+def error_object(e):
+    """Build the ErrorObject dict from an exception.
+
+    Mirrors JS `errorObject`: includes statusCode/statusMessage when the error
+    carries an HTTP `response`, and a `stack`-equivalent string.
+    """
+    response = getattr(e, "response", None)
+    result = {
+        "error": True,
+        "errorMsg": str(e),
+        "statusCode": getattr(response, "status_code", None) if response is not None else None,
+        "statusMessage": getattr(response, "reason", None) if response is not None else None,
+        "stack": getattr(e, "stack", None) or repr(e),
+    }
+    return result
+
+
+# JS-style alias.
+errorObject = error_object
+
+
+def pretty_check_result(result):
+    """Return a compact string representation of a check result (for logging)."""
+    if not isinstance(result, dict) or not result.get("domDump"):
+        return json.dumps(result)
+    dump = json.loads(result["domDump"])
+    res_obs = dict(result)
+    del res_obs["domDump"]
+    length = len(dump) if isinstance(dump, (list, str, dict)) else 0
+    res_obs["domDump"] = f"{json.dumps(dump)[:20]}... and about {length} items]"
+    return json.dumps(res_obs)
+
+
+prettyCheckResult = pretty_check_result

--- a/packages/core-api-python/tests/test_api_behavior.py
+++ b/packages/core-api-python/tests/test_api_behavior.py
@@ -1,0 +1,217 @@
+import responses
+
+from syngrisi_core_api import SyngrisiApi
+
+
+def _api():
+    return SyngrisiApi({"url": "http://localhost:3000/", "apiKey": "plain-api-key"})
+
+
+def _check_params():
+    return {
+        "name": "homepage",
+        "viewport": "1200x800",
+        "browserName": "chrome",
+        "os": "macOS",
+        "app": "MyProject",
+        "branch": "main",
+        "testId": "0123456789abcdef01234567",
+        "suite": "suite-name",
+        "browserVersion": "113",
+        "browserFullVersion": "113.0.0.0",
+        "hashCode": "a" * 64,
+    }
+
+
+# ----- two-phase coreCheck --------------------------------------------------
+
+@responses.activate
+def test_core_check_two_phase():
+    # Phase 1 returns requiredFileData (no file), phase 2 returns final result.
+    responses.add(
+        responses.POST,
+        "http://localhost:3000/v1/client/createCheck",
+        json={"status": "requiredFileData"},
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "http://localhost:3000/v1/client/createCheck",
+        json={"status": "new", "_id": "0123456789abcdef01234567"},
+        status=200,
+    )
+
+    api = _api()
+    result = api.core_check(b"image-bytes", _check_params())
+
+    assert result["status"] == "new"
+    assert len(responses.calls) == 2
+
+    # Phase 1 must NOT contain the file; phase 2 must.
+    body1 = responses.calls[0].request.body
+    body2 = responses.calls[1].request.body
+    body1_bytes = body1 if isinstance(body1, bytes) else str(body1).encode()
+    body2_bytes = body2 if isinstance(body2, bytes) else str(body2).encode()
+    assert b'name="file"' not in body1_bytes
+    assert b"image-bytes" not in body1_bytes
+    assert b'name="file"' in body2_bytes
+    assert b"image-bytes" in body2_bytes
+    # hashcode present in both phases.
+    assert b'name="hashcode"' in body1_bytes
+    assert b'name="hashcode"' in body2_bytes
+
+
+@responses.activate
+def test_core_check_single_phase_when_no_required_file_data():
+    responses.add(
+        responses.POST,
+        "http://localhost:3000/v1/client/createCheck",
+        json={"status": "passed", "_id": "0123456789abcdef01234567"},
+        status=200,
+    )
+
+    api = _api()
+    result = api.core_check(b"image-bytes", _check_params())
+
+    assert result["status"] == "passed"
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_core_check_failed_adds_message():
+    responses.add(
+        responses.POST,
+        "http://localhost:3000/v1/client/createCheck",
+        json={"status": "failed", "_id": "0123456789abcdef01234567"},
+        status=200,
+    )
+
+    api = _api()
+    result = api.core_check(b"image-bytes", _check_params())
+
+    assert result["status"] == "failed"
+    expected_view = "'http://localhost:3000/?checkId=0123456789abcdef01234567&modalIsOpen=true'"
+    assert result["vrsGroupLink"] == expected_view
+    assert result["vrsDiffLink"] == expected_view
+    assert expected_view in result["message"]
+
+
+# ----- requestWithRetry -----------------------------------------------------
+
+@responses.activate
+def test_request_with_retry_401_then_200():
+    responses.add(
+        responses.GET,
+        "http://localhost:3000/v1/client/getIdent",
+        json={"error": "unauthorized"},
+        status=401,
+    )
+    responses.add(
+        responses.GET,
+        "http://localhost:3000/v1/client/getIdent",
+        json=["app1", "app2"],
+        status=200,
+    )
+
+    api = _api()
+    api.retry_delay_ms = 0  # speed up the test
+
+    result = api.get_ident()
+    assert result == ["app1", "app2"]
+    assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_request_with_retry_non_401_returns_error_object_without_retry():
+    responses.add(
+        responses.GET,
+        "http://localhost:3000/v1/client/getIdent",
+        json={"error": "server"},
+        status=500,
+    )
+
+    api = _api()
+    api.retry_delay_ms = 0
+
+    result = api.get_ident()
+    assert isinstance(result, dict)
+    assert result["error"] is True
+    assert result["statusCode"] == 500
+    # No retry on non-401.
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_request_with_retry_persistent_401_exhausts_and_returns_error():
+    for _ in range(3):
+        responses.add(
+            responses.GET,
+            "http://localhost:3000/v1/client/getIdent",
+            json={"error": "unauthorized"},
+            status=401,
+        )
+
+    api = _api()
+    api.retry_delay_ms = 0
+
+    result = api.get_ident()
+    assert result["error"] is True
+    assert result["statusCode"] == 401
+    assert len(responses.calls) == 3
+
+
+# ----- acceptCheck / updateBaseline guards ----------------------------------
+
+@responses.activate
+def test_accept_check_missing_check_id_returns_error_no_http():
+    api = _api()
+    result = api.accept_check("", "baseline-id")
+    assert result["error"] is True
+    assert "checkId is required" in result["errorMsg"]
+    assert len(responses.calls) == 0
+
+
+@responses.activate
+def test_accept_check_missing_baseline_id_returns_error_no_http():
+    api = _api()
+    result = api.accept_check("check-id", "")
+    assert result["error"] is True
+    assert "baselineId is required" in result["errorMsg"]
+    assert len(responses.calls) == 0
+
+
+@responses.activate
+def test_accept_check_success():
+    responses.add(
+        responses.PUT,
+        "http://localhost:3000/v1/checks/check-id-123/accept",
+        json={"status": "accepted"},
+        status=200,
+    )
+    api = _api()
+    result = api.accept_check("check-id-123", "baseline-id-456")
+    assert result["status"] == "accepted"
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_update_baseline_missing_id_returns_error_no_http():
+    api = _api()
+    result = api.update_baseline("", {"ignoreRegions": "[]"})
+    assert result["error"] is True
+    assert "baselineId is required" in result["errorMsg"]
+    assert len(responses.calls) == 0
+
+
+@responses.activate
+def test_update_baseline_success():
+    responses.add(
+        responses.PUT,
+        "http://localhost:3000/v1/baselines/baseline-id-123",
+        json={"ok": True},
+        status=200,
+    )
+    api = _api()
+    result = api.update_baseline("baseline-id-123", {"ignoreRegions": "[]"})
+    assert result["ok"] is True
+    assert len(responses.calls) == 1

--- a/packages/core-api-python/tests/test_auth_headers.py
+++ b/packages/core-api-python/tests/test_auth_headers.py
@@ -1,0 +1,92 @@
+import os
+
+import pytest
+import responses
+
+from syngrisi_core_api import SyngrisiApi
+
+
+@pytest.fixture(autouse=True)
+def _reset_env():
+    os.environ.pop("SYNGRISI_AUTH_TOKEN", None)
+    yield
+    os.environ.pop("SYNGRISI_AUTH_TOKEN", None)
+
+
+@responses.activate
+def test_passes_headers_to_get_baselines():
+    responses.add(
+        responses.GET,
+        "http://localhost:3000/v1/client/baselines",
+        json={"results": []},
+        status=200,
+    )
+
+    api = SyngrisiApi({
+        "url": "http://localhost:3000/",
+        "apiKey": "plain-api-key",
+        "headers": {"X-Kanopy-Authorization": "Bearer token"},
+    })
+
+    api.get_baselines({
+        "name": "baseline",
+        "viewport": "1200x800",
+        "browserName": "chrome",
+        "os": "linux",
+        "app": "app",
+        "branch": "main",
+    })
+
+    assert len(responses.calls) == 1
+    req = responses.calls[0].request
+    assert req.headers["X-Kanopy-Authorization"] == "Bearer token"
+
+
+@responses.activate
+def test_adds_authorization_from_env_token_for_get_snapshots():
+    os.environ["SYNGRISI_AUTH_TOKEN"] = "env-token"
+    responses.add(
+        responses.GET,
+        "http://localhost:3000/v1/client/snapshots",
+        json={"results": []},
+        status=200,
+    )
+
+    api = SyngrisiApi({"url": "http://localhost:3000/", "apiKey": "plain-api-key"})
+
+    api.get_snapshots({"_id": "0123456789abcdef01234567"})
+
+    assert len(responses.calls) == 1
+    req = responses.calls[0].request
+    assert req.headers["Authorization"] == "Bearer env-token"
+
+
+@responses.activate
+def test_no_apikey_in_url_or_headers_when_apikey_omitted():
+    responses.add(
+        responses.GET,
+        "http://localhost:3000/v1/client/baselines",
+        json={"results": []},
+        status=200,
+    )
+
+    api = SyngrisiApi({
+        "url": "http://localhost:3000/",
+        "headers": {"Authorization": "Bearer token"},
+    })
+
+    api.get_baselines({
+        "name": "baseline",
+        "viewport": "1200x800",
+        "browserName": "chrome",
+        "os": "linux",
+        "app": "app",
+        "branch": "main",
+    })
+
+    assert len(responses.calls) == 1
+    req = responses.calls[0].request
+    assert "/v1/client/baselines?filter=" in req.url
+    assert "apikey=" not in req.url
+    assert "apikey" not in req.headers
+    assert req.headers["Authorization"] == "Bearer token"

--- a/packages/core-api-python/tests/test_compression.py
+++ b/packages/core-api-python/tests/test_compression.py
@@ -1,0 +1,100 @@
+from syngrisi_core_api import (
+    DOM_DUMP_COMPRESSION_THRESHOLD,
+    compress_dom_dump,
+    decompress_dom_dump,
+    is_compressed_dom_dump,
+    prepare_dom_dump_for_transfer,
+)
+
+
+def _small_dump():
+    return {
+        "tagName": "body",
+        "attributes": {},
+        "rect": {"x": 0, "y": 0, "width": 100, "height": 100},
+        "computedStyles": {"display": "block"},
+        "children": [],
+    }
+
+
+def _large_dump():
+    # Build a dump that exceeds the 50KB threshold.
+    children = []
+    for i in range(2000):
+        children.append({
+            "tagName": "div",
+            "attributes": {"id": f"node-{i}", "class": "some-long-class-name-here"},
+            "rect": {"x": i, "y": i, "width": 50, "height": 50},
+            "computedStyles": {"display": "block", "color": "rgb(10, 20, 30)"},
+            "children": [],
+            "text": f"text content for node number {i}",
+        })
+    return {
+        "tagName": "body",
+        "attributes": {},
+        "rect": {"x": 0, "y": 0, "width": 1000, "height": 1000},
+        "computedStyles": {},
+        "children": children,
+    }
+
+
+def test_small_dump_not_compressed():
+    dump = _small_dump()
+    result = compress_dom_dump(dump)
+    assert isinstance(result, str)
+    assert not is_compressed_dom_dump(result)
+
+
+def test_large_dump_is_compressed():
+    dump = _large_dump()
+    result = compress_dom_dump(dump)
+    assert is_compressed_dom_dump(result)
+    assert result["compressed"] is True
+    assert isinstance(result["data"], str)
+    assert result["originalSize"] > DOM_DUMP_COMPRESSION_THRESHOLD
+
+
+def test_round_trip_large():
+    dump = _large_dump()
+    compressed = compress_dom_dump(dump)
+    assert is_compressed_dom_dump(compressed)
+    restored = decompress_dom_dump(compressed)
+    assert restored == dump
+
+
+def test_round_trip_small_string():
+    dump = _small_dump()
+    compressed = compress_dom_dump(dump)  # returns JSON string for small dumps
+    restored = decompress_dom_dump(compressed)
+    assert restored == dump
+
+
+def test_is_compressed_dom_dump_true_false():
+    assert is_compressed_dom_dump({"compressed": True, "data": "abc"}) is True
+    assert is_compressed_dom_dump({"compressed": False, "data": "abc"}) is False
+    assert is_compressed_dom_dump({"data": "abc"}) is False
+    assert is_compressed_dom_dump("just a string") is False
+    assert is_compressed_dom_dump(None) is False
+
+
+def test_prepare_dom_dump_for_transfer_small():
+    prepared = prepare_dom_dump_for_transfer(_small_dump())
+    assert prepared["isCompressed"] is False
+    assert isinstance(prepared["data"], str)
+
+
+def test_prepare_dom_dump_for_transfer_large():
+    prepared = prepare_dom_dump_for_transfer(_large_dump())
+    assert prepared["isCompressed"] is True
+    # data is a JSON-stringified CompressedDomDump
+    assert '"compressed":true' in prepared["data"]
+
+
+def test_prepare_already_compressed():
+    already = {"compressed": True, "data": "abc", "originalSize": 123}
+    prepared = prepare_dom_dump_for_transfer(already)
+    assert prepared["isCompressed"] is True
+
+
+def test_decompress_invalid_returns_none():
+    assert decompress_dom_dump("{ not valid json") is None

--- a/packages/core-api-python/tests/test_constructor_transform.py
+++ b/packages/core-api-python/tests/test_constructor_transform.py
@@ -1,0 +1,35 @@
+import pytest
+
+from syngrisi_core_api import SyngrisiApi, transform_os
+from syngrisi_core_api.schemas import ValidationError
+
+
+class TestConstructor:
+    def test_create_instance_with_valid_config(self):
+        api = SyngrisiApi({"url": "http://localhost:3000/", "apiKey": "test-api-key"})
+        assert isinstance(api, SyngrisiApi)
+
+    def test_throws_with_missing_url(self):
+        with pytest.raises(ValidationError):
+            SyngrisiApi({"apiKey": "test"})
+
+    def test_create_instance_without_apikey(self):
+        api = SyngrisiApi({"url": "http://localhost:3000/"})
+        assert isinstance(api, SyngrisiApi)
+
+
+class TestTransformOs:
+    def test_unknown_returned_unchanged(self):
+        assert transform_os("UnknownOS") == "UnknownOS"
+
+    def test_macintel_to_macos(self):
+        assert transform_os("macintel") == "macOS"
+
+    def test_win32_to_windows(self):
+        assert transform_os("win32") == "WINDOWS"
+
+    def test_linux_unchanged(self):
+        assert transform_os("linux") == "linux"
+
+    def test_darwin_unchanged(self):
+        assert transform_os("darwin") == "darwin"


### PR DESCRIPTION
## What

Two new ports of **`@syngrisi/core-api`** (v3.6.0) with **full functional parity** to the JS package and **analogous tests, all green**.

### `packages/core-api-python` — `requests`, pytest
**31 passed.** `SyngrisiApi` (start/stop session, two-phase `coreCheck`, `getIdent`, `getBaselines`, `getSnapshots`, `acceptCheck`, `updateBaseline`, `requestWithRetry` with 401 retry, computed auth headers: apikey SHA-512 hash + `SYNGRISI_AUTH_TOKEN` fallback), `transformOs`, `errorObject`, gzip+base64 DOM-dump compression (50 KB threshold), `COLLECT_DOM_TREE_SCRIPT`, manual schema validation (throws on invalid). Auth-header tests use the `responses` lib to capture the real request.

```
cd packages/core-api-python && python3 -m venv .venv && .venv/bin/pip install requests responses pytest && .venv/bin/pytest -q
```

### `packages/core-api-groovy` — JDK `HttpClient`, Spock
**25 tests, 0 failures.** Same surface; multipart/form-data built manually; auth-header tests stub a real `com.sun.net.httpserver.HttpServer`. Groovy 4.0.22 / Spock 2.3-groovy-4.0 / Java 21 toolchain.

```
JAVA_HOME="$(sdk home java 21.0.4-tem)" gradle test   # Gradle 8.10.2 needs a JDK <=22 launcher
```

## Parity
Header names (`x-syngrisi-sdk-version`, `apikey`, `Authorization`, `x-domdump-compressed: gzip`), multipart field mapping (`app→appName`, `suite→suitename`, `testId→testid`, `file`, `hashcode`, `domdump`), URL shapes (`${url}v1/client/...`, `?filter=...&apikey=...`, `/v1/checks/{id}/accept`, `/v1/baselines/{id}`), and the **return-ErrorObject-instead-of-throw** contract all match the JS package exactly. Validation throws; HTTP methods return an error object. No machine-specific paths committed (see `gradle.properties`). The JS package is untouched.

## Tests
Both suites verified green independently after implementation: Python `31 passed`, Groovy `25 tests, 0 failures, 0 errors, 0 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)