### PR TITLE
docs: link Python and Java Playwright boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ start from the plain
 [Playwright](https://github.com/syngrisi/syngrisi-playwright-boilerplate) or
 [Cucumber](https://github.com/syngrisi/syngrisi-cucumber-boilerplate) boilerplate
 ([▶ open in Gitpod](https://gitpod.io/#https://github.com/syngrisi/syngrisi-cucumber-boilerplate)).
+Testing in another language? There are also
+[Playwright + Python](https://github.com/syngrisi/syngrisi-playwright-python-boilerplate) and
+[Playwright + Java](https://github.com/syngrisi/syngrisi-playwright-java-boilerplate) boilerplates.
 
 ### Run the server with Docker
 


### PR DESCRIPTION
Adds links to the two new language boilerplates in the Quick Start list:
- [syngrisi-playwright-python-boilerplate](https://github.com/syngrisi/syngrisi-playwright-python-boilerplate)
- [syngrisi-playwright-java-boilerplate](https://github.com/syngrisi/syngrisi-playwright-java-boilerplate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)