### PR TITLE
fix: AI Triage/RCA hardening + admin-panel bug fixes

### DIFF
--- a/.changeset/ai-triage-hardening.md
+++ b/.changeset/ai-triage-hardening.md
@@ -1,0 +1,20 @@
+---
+"@syngrisi/syngrisi": patch
+---
+
+Harden the AI Triage / RCA subsystem and fix several admin-panel bugs
+
+Security and reliability:
+- Require authentication and the admin role, and validate the request body with a strict schema, on `PATCH /v1/app/:id/triage-policy`; require authentication on `GET /v1/app` (both were previously reachable without auth).
+- Escape user- and DB-derived data rendered into the `/ai/*` HTML views (reflected and stored XSS).
+- Scope the `OPENAI_API_KEY` / OpenAI base URL to the openai provider only, so they no longer leak to Anthropic, Gemini, or a custom-baseUrl provider.
+- Stop reflecting raw upstream response bodies from the AI provider "Test connection" check.
+- Make the AI Triage queue "restart all" asynchronous (re-queues via the background scheduler instead of blocking the HTTP request), and retry transient provider failures a bounded number of times instead of permanently marking a check failed.
+
+Admin panel:
+- Confirm before restoring the database and before deleting a backup job, and guard those action buttons against double-submit.
+- "Test connection" no longer sends the masked `***` API-key placeholder; the server backfills the stored key.
+- Keep the user row in edit mode until a save succeeds and resync the row with server state on refetch.
+- Resync the settings and plugin-settings forms with server state; use a proper numeric input instead of forcing an empty value to `0`; remove leftover debug logging.
+- Confirm before discarding unsaved AI Triage edits when switching projects, and disable window-focus refetch that could silently overwrite them; use stable keys for the verdict/example rows.
+- Add `rel="noopener noreferrer"` to the external documentation link and fix the log-refresh pluralization.

--- a/packages/syngrisi/e2e/features/CP/admin/data_management.feature
+++ b/packages/syngrisi/e2e/features/CP/admin/data_management.feature
@@ -30,6 +30,7 @@ Feature: Admin Data Management
       """
     When I upload stored file "dbBackupDownload" into file input "Database archive"
     When I click the 1st button "Upload and Restore Database"
+    And I click the 1st button "Confirm Restore"
     Then the latest admin data job "Database Restore" should have status "completed" with message containing "Database restore completed"
 
   Scenario: Admin can back up screenshots through the UI
@@ -75,6 +76,7 @@ Feature: Admin Data Management
     Then the latest admin data job "Database Backup" should have status "completed" with message containing "Database backup completed"
     Then the admin data jobs count should be 1
     When I click the 1st button "Delete"
+    And I click the 1st button "Confirm Delete"
     Then the admin data jobs count should be 0
 
   Scenario: Admin sees an error for an invalid database archive
@@ -84,4 +86,5 @@ Feature: Admin Data Management
       """
     And I upload stored file "invalidDbArchive" into file input "Database archive"
     And I click the 1st button "Upload and Restore Database"
+    And I click the 1st button "Confirm Restore"
     Then the latest admin data job "Database Restore" should have status "failed" with message containing "manifest.json is missing from database archive"

--- a/packages/syngrisi/src/server/controllers/ai.controller.ts
+++ b/packages/syngrisi/src/server/controllers/ai.controller.ts
@@ -697,7 +697,10 @@ const triageTest = catchAsync(async (req: ExtRequest, res: Response) => {
         const result = await createProvider(cfg).ping();
         res.json({ ok: true, latencyMs: Date.now() - started, result });
     } catch (e) {
-        res.json({ ok: false, latencyMs: Date.now() - started, error: e instanceof Error ? e.message : String(e) });
+        // Belt-and-suspenders cap: providers no longer inline upstream response bodies,
+        // but keep the message short regardless of what threw.
+        const message = (e instanceof Error ? e.message : String(e)).slice(0, 200);
+        res.json({ ok: false, latencyMs: Date.now() - started, error: message });
     }
 });
 

--- a/packages/syngrisi/src/server/controllers/ai.controller.ts
+++ b/packages/syngrisi/src/server/controllers/ai.controller.ts
@@ -690,9 +690,16 @@ const triageQueueRestart = catchAsync(async (req: ExtRequest, res: Response) => 
 
 // Admin "Test connection": run one classification against the current/provided provider config.
 const triageTest = catchAsync(async (req: ExtRequest, res: Response) => {
-    const cfg = (req.body && Object.keys(req.body).length) ? req.body : await getProviderConfig();
+    let cfg = (req.body && Object.keys(req.body).length) ? req.body : await getProviderConfig();
     if (!cfg) {
         throw new ApiError(HttpStatus.BAD_REQUEST, 'No triage provider configured');
+    }
+    // The admin form omits the apiKey (or sends the masked placeholder) when the stored key
+    // wasn't retyped. Backfill it from the stored provider config, mirroring the save path's
+    // preservation logic, so "Test connection" authenticates with the real stored secret.
+    if (!cfg.apiKey || cfg.apiKey === '***') {
+        const stored = await getProviderConfig();
+        cfg = { ...cfg, apiKey: stored?.apiKey || '' };
     }
     const started = Date.now();
     try {

--- a/packages/syngrisi/src/server/controllers/ai.controller.ts
+++ b/packages/syngrisi/src/server/controllers/ai.controller.ts
@@ -9,7 +9,7 @@ import { accept, remove } from '@services/check.service';
 import { ExtRequest } from '@types';
 import log from '@lib/logger';
 import { HttpStatus } from '@utils';
-import { triageCheck, cancelCheck } from '@services/triage';
+import { triageCheck, cancelCheck, requeueCheck } from '@services/triage';
 import { createProvider } from '@services/triage/factory';
 import { getProviderConfig } from '@services/triage/config';
 
@@ -680,8 +680,12 @@ const bulkTriageOp = async (body: any, op: (id: string) => Promise<unknown>) => 
 const triageQueueCancel = catchAsync(async (req: ExtRequest, res: Response) => {
     res.json({ results: await bulkTriageOp(req.body, cancelCheck) });
 });
+// Restart re-queues each check (mark pending + kick the scheduler) instead of running the full
+// classification inline — "restart all" on a large run must not block the HTTP request for
+// minutes. The background scheduler picks the checks back up. The per-check toolbar "re-run"
+// stays synchronous (triageRun -> triageCheck below), since the user is waiting on one result.
 const triageQueueRestart = catchAsync(async (req: ExtRequest, res: Response) => {
-    res.json({ results: await bulkTriageOp(req.body, triageCheck) });
+    res.json({ results: await bulkTriageOp(req.body, requeueCheck) });
 });
 
 // Admin "Test connection": run one classification against the current/provided provider config.

--- a/packages/syngrisi/src/server/controllers/ai.controller.ts
+++ b/packages/syngrisi/src/server/controllers/ai.controller.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Response } from 'express';
 import { Check, Webhook, App, Run, Test } from '@models';
-import { catchAsync, ApiError } from '@utils';
+import { catchAsync, ApiError, escapeHtml } from '@utils';
 import { config } from '@config';
 import fs from 'fs';
 import path from 'path';
@@ -13,13 +13,15 @@ import { triageCheck, cancelCheck } from '@services/triage';
 import { createProvider } from '@services/triage/factory';
 import { getProviderConfig } from '@services/triage/config';
 
-const htmlShell = (title: string, content: string) => `
+const htmlShell = (title: string, content: string) => {
+    const safeTitle = escapeHtml(title);
+    return `
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>${title}</title>
+    <title>${safeTitle}</title>
     <style>
         body { font-family: system-ui, sans-serif; max-width: 800px; margin: 0 auto; padding: 1rem; }
         header, footer { margin-bottom: 1rem; border-bottom: 1px solid #ccc; padding-bottom: 0.5rem; }
@@ -37,7 +39,7 @@ const htmlShell = (title: string, content: string) => `
 </head>
 <body>
     <header>
-        <h1>${title}</h1>
+        <h1>${safeTitle}</h1>
         <nav><a href="/ai/checks">Checks</a></nav>
     </header>
     <main>
@@ -49,6 +51,7 @@ const htmlShell = (title: string, content: string) => `
 </body>
 </html>
 `;
+};
 
 const getIndex = (req: ExtRequest, res: Response) => {
     const today = new Date().toISOString().split('T')[0];
@@ -291,13 +294,13 @@ const getChecks = catchAsync(async (req: ExtRequest, res: Response) => {
         <section aria-labelledby="filter-form">
             <h2 id="filter-form" class="sr-only">Filter Checks</h2>
             <form method="GET" aria-label="Check filter form" style="display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1rem; padding: 0.5rem; background: #f9f9f9;">
-                <input type="text" name="run" placeholder="Run ID" value="${run || ''}" aria-label="Run ID">
-                <input type="text" name="status" placeholder="Status" value="${status || ''}" aria-label="Status">
-                <input type="text" name="name" placeholder="Name (regex)" value="${name || ''}" aria-label="Check name">
-                <input type="text" name="branch" placeholder="Branch" value="${branch || ''}" aria-label="Branch">
-                <input type="text" name="browser" placeholder="Browser" value="${browser || ''}" aria-label="Browser">
-                <input type="text" name="os" placeholder="OS" value="${os || ''}" aria-label="Operating system">
-                <input type="text" name="viewport" placeholder="Viewport" value="${viewport || ''}" aria-label="Viewport">
+                <input type="text" name="run" placeholder="Run ID" value="${escapeHtml(run)}" aria-label="Run ID">
+                <input type="text" name="status" placeholder="Status" value="${escapeHtml(status)}" aria-label="Status">
+                <input type="text" name="name" placeholder="Name (regex)" value="${escapeHtml(name)}" aria-label="Check name">
+                <input type="text" name="branch" placeholder="Branch" value="${escapeHtml(branch)}" aria-label="Branch">
+                <input type="text" name="browser" placeholder="Browser" value="${escapeHtml(browser)}" aria-label="Browser">
+                <input type="text" name="os" placeholder="OS" value="${escapeHtml(os)}" aria-label="Operating system">
+                <input type="text" name="viewport" placeholder="Viewport" value="${escapeHtml(viewport)}" aria-label="Viewport">
                 <select name="markedAs" aria-label="Marked as">
                     <option value="">Marked As...</option>
                     <option value="accepted" ${markedAs === 'accepted' ? 'selected' : ''}>Accepted</option>
@@ -306,9 +309,9 @@ const getChecks = catchAsync(async (req: ExtRequest, res: Response) => {
                 <label>
                     <input type="checkbox" name="hasDiff" value="true" ${hasDiff === 'true' ? 'checked' : ''}> Has Diff
                 </label>
-                <input type="date" name="fromDate" value="${fromDate || ''}" aria-label="From date">
-                <input type="date" name="toDate" value="${toDate || ''}" aria-label="To date">
-                <input type="number" name="lastSeconds" placeholder="Last X seconds" value="${lastSeconds || ''}" aria-label="Last seconds" min="1">
+                <input type="date" name="fromDate" value="${escapeHtml(fromDate)}" aria-label="From date">
+                <input type="date" name="toDate" value="${escapeHtml(toDate)}" aria-label="To date">
+                <input type="number" name="lastSeconds" placeholder="Last X seconds" value="${escapeHtml(lastSeconds)}" aria-label="Last seconds" min="1">
                 <select name="limit" aria-label="Items per page">
                     <option value="20" ${itemsPerPage === 20 ? 'selected' : ''}>20 per page</option>
                     <option value="50" ${itemsPerPage === 50 ? 'selected' : ''}>50 per page</option>
@@ -342,13 +345,13 @@ const getChecks = catchAsync(async (req: ExtRequest, res: Response) => {
                     <li>
                         <article style="border: 1px solid #eee; padding: 1rem; margin-bottom: 1rem; border-radius: 4px;">
                             <label style="display: flex; gap: 1rem; align-items: start;">
-                                <input type="checkbox" name="ids" value="${check._id}" aria-label="Select ${check.name}">
+                                <input type="checkbox" name="ids" value="${check._id}" aria-label="Select ${escapeHtml(check.name)}">
                                 <div style="flex: 1;">
-                                    <h3 style="margin: 0 0 0.5rem 0;"><a href="/ai/checks/${check._id}">${check.name}</a></h3>
-                                    <p style="margin: 0 0 0.5rem 0;">Status: <span class="status-${check.status[0]}">${check.status[0]}</span></p>
+                                    <h3 style="margin: 0 0 0.5rem 0;"><a href="/ai/checks/${check._id}">${escapeHtml(check.name)}</a></h3>
+                                    <p style="margin: 0 0 0.5rem 0;">Status: <span class="status-${escapeHtml(check.status[0])}">${escapeHtml(check.status[0])}</span></p>
                                     <dl class="meta" style="margin: 0; display: grid; grid-template-columns: auto 1fr; gap: 0.25rem 0.5rem;">
                                         <dt>ID:</dt><dd style="margin: 0;">${check._id}</dd>
-                                        <dt>Run:</dt><dd style="margin: 0;">${check.run}</dd>
+                                        <dt>Run:</dt><dd style="margin: 0;">${escapeHtml(check.run)}</dd>
                                         <dt>Date:</dt><dd style="margin: 0;">${new Date(check.createdDate).toISOString()}</dd>
                                     </dl>
                                 </div>
@@ -397,14 +400,14 @@ const getCheckDetails = catchAsync(async (req: ExtRequest, res: Response) => {
         return;
     }
 
-    const actual = check.actualSnapshotId ? `/ snapshoots / ${check.actualSnapshotId.filename} ` : '';
-    const baseline = check.baselineId ? `/ snapshoots / ${check.baselineId.filename} ` : '';
-    const diff = check.diffId ? `/ snapshoots / ${check.diffId.filename} ` : '';
+    const actual = check.actualSnapshotId ? `/ snapshoots / ${escapeHtml(check.actualSnapshotId.filename)} ` : '';
+    const baseline = check.baselineId ? `/ snapshoots / ${escapeHtml(check.baselineId.filename)} ` : '';
+    const diff = check.diffId ? `/ snapshoots / ${escapeHtml(check.diffId.filename)} ` : '';
 
     let html = `
         <article>
-            <h2>${check.name}</h2>
-            <p>Status: ${check.status[0]}</p>
+            <h2>${escapeHtml(check.name)}</h2>
+            <p>Status: ${escapeHtml(check.status[0])}</p>
             <p>ID: ${check._id}</p>
             <div style="display: flex; gap: 1rem; flex-wrap: wrap;">
     `;
@@ -437,7 +440,7 @@ const getCheckDetails = catchAsync(async (req: ExtRequest, res: Response) => {
     html += `
             </div>
             <h3>Metadata</h3>
-            <pre>${JSON.stringify(check.meta || {}, null, 2)}</pre>
+            <pre>${escapeHtml(JSON.stringify(check.meta || {}, null, 2))}</pre>
             <h3>Actions</h3>
             <form method="POST" action="/ai/batch">
                 <input type="hidden" name="ids" value="${check._id}">
@@ -447,7 +450,7 @@ const getCheckDetails = catchAsync(async (req: ExtRequest, res: Response) => {
         </article>
     `;
 
-    res.send(htmlShell(`Check: ${check.name} `, html));
+    res.send(htmlShell(`Check: ${check.name} `, html)); // htmlShell escapes the title internally
 });
 
 const getAnalysis = catchAsync(async (req: ExtRequest, res: Response) => {

--- a/packages/syngrisi/src/server/envConfig.ts
+++ b/packages/syngrisi/src/server/envConfig.ts
@@ -59,6 +59,7 @@ export const env = cleanEnv(process.env, {
     // AI Triage
     SYNGRISI_AI_TRIAGE_POLL_INTERVAL_MS: num({ default: 30 * 1000 }),
     SYNGRISI_AI_TRIAGE_BATCH_SIZE: num({ default: 10 }),
+    SYNGRISI_AI_TRIAGE_MAX_ATTEMPTS: num({ default: 3 }), // give up and stamp a failed verdict after this many attempts
     SYNGRISI_V8_COVERAGE_ON_EXIT: bool({ default: false }),
 
     // Rate Limiting

--- a/packages/syngrisi/src/server/models/Check.model.ts
+++ b/packages/syngrisi/src/server/models/Check.model.ts
@@ -49,6 +49,7 @@ export interface CheckDocument extends Document {
         icon?: string;
         autoAccepted?: boolean;
         failed?: boolean; // provider error/timeout → fallback verdict
+        attempts?: number; // number of classification attempts made so far (bounded retry)
     };
     changeSig?: {
         vector: number[]; // color_hist Lab descriptor of the change (resolution-invariant)
@@ -197,6 +198,7 @@ const CheckSchema = new Schema<CheckDocument>({
             icon: { type: String },
             autoAccepted: { type: Boolean },
             failed: { type: Boolean },
+            attempts: { type: Number },
         },
         _id: false,
         default: undefined,

--- a/packages/syngrisi/src/server/routes/v1/app.route.ts
+++ b/packages/syngrisi/src/server/routes/v1/app.route.ts
@@ -4,11 +4,16 @@ import { appController } from '@controllers';
 import { Midleware } from '@types';
 import { validateRequest } from '@utils/validateRequest';
 import { AppInfoRespSchema, AppRespSchema } from '@root/src/server/schemas/App.schema';
+import { AppTriagePolicyUpdateSchema } from '@root/src/server/schemas/AppTriagePolicy.schema';
 import {
     createApiResponse,
     createPaginatedApiResponse,
 } from '@api-docs/openAPIResponseBuilders';
 import { SkipValid } from '@schemas/SkipValid.schema';
+import { ensureLoggedIn } from '@middlewares/ensureLogin';
+import { ensureLoggedInOrApiKey } from '@middlewares/ensureLogin/ensureLoggedIn';
+import { authorization } from '@middlewares';
+import { createRequestBodySchema } from '../../schemas/utils/createRequestBodySchema';
 import { RequestPaginationSchema } from '../../schemas/common/RequestPagination.schema';
 import { createRequestQuerySchema } from '../../schemas/utils/createRequestQuerySchema';
 
@@ -55,13 +60,16 @@ registry.registerPath({
 
 router.get(
     '/',
+    ensureLoggedInOrApiKey(),
     validateRequest(createRequestQuerySchema(RequestPaginationSchema), 'get, /v1/app'),
     appController.get as Midleware
 );
 
 router.patch(
     '/:id/triage-policy',
-    validateRequest(SkipValid, 'patch, /v1/app/:id/triage-policy'),
+    ensureLoggedIn(),
+    authorization('admin') as Midleware,
+    validateRequest(createRequestBodySchema(AppTriagePolicyUpdateSchema), 'patch, /v1/app/:id/triage-policy'),
     appController.updateTriagePolicy as Midleware
 );
 

--- a/packages/syngrisi/src/server/schemas/AppTriagePolicy.schema.ts
+++ b/packages/syngrisi/src/server/schemas/AppTriagePolicy.schema.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod';
+
+// This file intentionally avoids path-aliased imports (e.g. `@schemas/utils`) so it can be
+// imported directly via a relative path from tests run with plain `tsx --test`, which does
+// not resolve tsconfig path aliases. Keep it dependency-free (zod only).
+
+// Reserved service verdict keys — must stay in sync with `services/triage/verdicts.ts`
+// (UNKNOWN_VERDICT / CANCELLED_VERDICT). Custom verdict sets may not reuse them.
+const RESERVED_VERDICT_KEYS = ['unknown', 'cancelled'] as const;
+
+const TriagePolicySchema = z.object({
+    policy: z.enum(['suggest', 'auto']).optional(),
+    autoAcceptThreshold: z.number().int().min(0).max(10).optional(),
+    autoAcceptVerdicts: z.array(z.string().max(64)).max(50).optional(),
+}).strict();
+
+const TriageVerdictSchema = z.object({
+    key: z.string().min(1).max(64).regex(/^[a-z0-9_-]+$/i, 'key must match /^[a-z0-9_-]+$/i'),
+    label: z.string().max(128),
+    color: z.string().max(64),
+    icon: z.string().max(64).optional(),
+    severity: z.number(),
+    autoAcceptable: z.boolean(),
+    neverAutoAccept: z.boolean().optional(),
+    isFallback: z.boolean().optional(),
+    description: z.string().max(2000).optional(),
+}).strict();
+
+const TriageVerdictsSchema = z.array(TriageVerdictSchema).max(20).superRefine((verdicts, ctx) => {
+    if (verdicts.length === 0) return;
+
+    const seenKeys = new Set<string>();
+    verdicts.forEach((verdict, index) => {
+        if (seenKeys.has(verdict.key)) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: `duplicate verdict key: '${verdict.key}'`,
+                path: [index, 'key'],
+            });
+        }
+        seenKeys.add(verdict.key);
+
+        if ((RESERVED_VERDICT_KEYS as readonly string[]).includes(verdict.key)) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: `'${verdict.key}' is a reserved service verdict key`,
+                path: [index, 'key'],
+            });
+        }
+    });
+
+    if (!verdicts.some((verdict) => verdict.isFallback)) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'at least one verdict must be marked as isFallback: true',
+        });
+    }
+});
+
+const TriageExampleSchema = z.object({
+    verdict: z.string().min(1),
+    image: z.string().max(2_000_000).startsWith('data:image/', 'image must be a data URL (data:image/...)'),
+    note: z.string().max(500).optional(),
+});
+
+export const AppTriagePolicyUpdateSchema = z.object({
+    triageEnabled: z.union([z.boolean(), z.enum(['true', 'false'])]).optional(),
+    triagePolicy: TriagePolicySchema.optional(),
+    triageVerdicts: TriageVerdictsSchema.optional(),
+    triagePrompt: z.string().max(20000).optional(),
+    triageExamples: z.array(TriageExampleSchema).max(20).optional(),
+    changeSimGate: z.number().min(0).max(1).optional(),
+}).strict();
+
+export type AppTriagePolicyUpdateType = z.infer<typeof AppTriagePolicyUpdateSchema>;

--- a/packages/syngrisi/src/server/schemas/__tests__/AppTriagePolicy.schema.test.ts
+++ b/packages/syngrisi/src/server/schemas/__tests__/AppTriagePolicy.schema.test.ts
@@ -1,0 +1,108 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AppTriagePolicyUpdateSchema } from '../AppTriagePolicy.schema';
+import { createRequestBodySchema } from '../utils/createRequestBodySchema';
+
+const validBody = {
+    triageEnabled: true,
+    triagePolicy: {
+        policy: 'auto',
+        autoAcceptThreshold: 5,
+        autoAcceptVerdicts: ['noise'],
+    },
+    triageVerdicts: [
+        {
+            key: 'noise',
+            label: 'Noise',
+            color: 'gray',
+            icon: 'wave',
+            severity: 1,
+            autoAcceptable: true,
+            description: 'pixels differ but the UI is effectively unchanged',
+        },
+        {
+            key: 'uncertain',
+            label: 'Uncertain',
+            color: 'yellow',
+            severity: 3,
+            autoAcceptable: false,
+            neverAutoAccept: true,
+            isFallback: true,
+        },
+    ],
+    triagePrompt: 'Classify the visual diff.',
+    triageExamples: [
+        {
+            verdict: 'noise',
+            image: 'data:image/png;base64,AAAA',
+            note: 'anti-aliasing shift',
+        },
+    ],
+    changeSimGate: 0.8,
+};
+
+// Regression: PATCH /v1/app/:id/triage-policy used SkipValid (z.any()), so an unauthenticated
+// caller could push an arbitrary payload and, e.g., flip the policy to 'auto'. This schema
+// enforces the shape of every field the controller reads.
+test('triage policy schema accepts a valid full payload', () => {
+    const schema = createRequestBodySchema(AppTriagePolicyUpdateSchema);
+    const parsed = schema.parse({ body: validBody }) as { body: Record<string, unknown> };
+    assert.equal((parsed.body.triagePolicy as Record<string, unknown>).policy, 'auto');
+});
+
+test('triage policy schema accepts an empty body (all fields optional)', () => {
+    const schema = createRequestBodySchema(AppTriagePolicyUpdateSchema);
+    const parsed = schema.parse({ body: {} }) as { body: Record<string, unknown> };
+    assert.deepEqual(parsed.body, {});
+});
+
+test('triage policy schema rejects duplicate verdict keys', () => {
+    const schema = createRequestBodySchema(AppTriagePolicyUpdateSchema);
+    const body = {
+        triageVerdicts: [
+            { key: 'noise', label: 'Noise', color: 'gray', severity: 1, autoAcceptable: true, isFallback: true },
+            { key: 'noise', label: 'Noise 2', color: 'gray', severity: 1, autoAcceptable: true },
+        ],
+    };
+    assert.throws(() => schema.parse({ body }));
+});
+
+test('triage policy schema rejects the reserved "cancelled" verdict key', () => {
+    const schema = createRequestBodySchema(AppTriagePolicyUpdateSchema);
+    const body = {
+        triageVerdicts: [
+            { key: 'cancelled', label: 'Cancelled', color: 'gray', severity: 0, autoAcceptable: false, isFallback: true },
+        ],
+    };
+    assert.throws(() => schema.parse({ body }));
+});
+
+test('triage policy schema rejects a verdict set without an isFallback verdict', () => {
+    const schema = createRequestBodySchema(AppTriagePolicyUpdateSchema);
+    const body = {
+        triageVerdicts: [
+            { key: 'noise', label: 'Noise', color: 'gray', severity: 1, autoAcceptable: true },
+        ],
+    };
+    assert.throws(() => schema.parse({ body }));
+});
+
+test('triage policy schema rejects autoAcceptThreshold out of range', () => {
+    const schema = createRequestBodySchema(AppTriagePolicyUpdateSchema);
+    const body = { triagePolicy: { autoAcceptThreshold: 11 } };
+    assert.throws(() => schema.parse({ body }));
+});
+
+test('triage policy schema rejects an example image that is not a data URL', () => {
+    const schema = createRequestBodySchema(AppTriagePolicyUpdateSchema);
+    const body = {
+        triageExamples: [{ verdict: 'noise', image: 'https://example.com/image.png' }],
+    };
+    assert.throws(() => schema.parse({ body }));
+});
+
+test('triage policy schema rejects unknown top-level keys', () => {
+    const schema = createRequestBodySchema(AppTriagePolicyUpdateSchema);
+    const body = { ...validBody, unexpectedField: 'nope' };
+    assert.throws(() => schema.parse({ body }));
+});

--- a/packages/syngrisi/src/server/services/triage/__tests__/mergeProviderConfig.test.ts
+++ b/packages/syngrisi/src/server/services/triage/__tests__/mergeProviderConfig.test.ts
@@ -1,0 +1,104 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mergeProviderConfig } from '../mergeProviderConfig';
+
+test('openai type: OPENAI_API_KEY wins, OPENAI_API_BASE_URL applied', () => {
+    const result = mergeProviderConfig(
+        { type: 'openai' },
+        { OPENAI_API_KEY: 'sk-openai', OPENAI_API_BASE_URL: 'https://custom.openai.example/v1' },
+    );
+    assert.equal(result?.apiKey, 'sk-openai');
+    assert.equal(result?.baseUrl, 'https://custom.openai.example/v1');
+});
+
+test('anthropic type with only OPENAI_API_KEY set: apiKey is undefined, not the openai key', () => {
+    const result = mergeProviderConfig(
+        { type: 'anthropic' },
+        { OPENAI_API_KEY: 'sk-openai' },
+    );
+    assert.equal(result?.apiKey, undefined);
+});
+
+test('anthropic type: cfg.apiKey used if present, OPENAI_API_KEY is not applied', () => {
+    const result = mergeProviderConfig(
+        { type: 'anthropic', apiKey: 'db-anthropic-key' },
+        { OPENAI_API_KEY: 'sk-openai' },
+    );
+    assert.equal(result?.apiKey, 'db-anthropic-key');
+});
+
+test('anthropic type: OPENAI_API_BASE_URL is NOT applied to baseUrl', () => {
+    const result = mergeProviderConfig(
+        { type: 'anthropic' },
+        { OPENAI_API_BASE_URL: 'https://api.openai.com/v1' },
+    );
+    assert.equal(result?.baseUrl, undefined);
+});
+
+test('anthropic type: cfg.baseUrl used if present', () => {
+    const result = mergeProviderConfig(
+        { type: 'anthropic', baseUrl: 'https://api.anthropic.com' },
+        { OPENAI_API_BASE_URL: 'https://api.openai.com/v1' },
+    );
+    assert.equal(result?.baseUrl, 'https://api.anthropic.com');
+});
+
+test('SYNGRISI_AI_KEY applies to any provider type', () => {
+    const anthropic = mergeProviderConfig({ type: 'anthropic' }, { SYNGRISI_AI_KEY: 'generic-key' });
+    const gemini = mergeProviderConfig({ type: 'gemini' }, { SYNGRISI_AI_KEY: 'generic-key' });
+    const openai = mergeProviderConfig({ type: 'openai' }, { SYNGRISI_AI_KEY: 'generic-key' });
+    assert.equal(anthropic?.apiKey, 'generic-key');
+    assert.equal(gemini?.apiKey, 'generic-key');
+    assert.equal(openai?.apiKey, 'generic-key');
+});
+
+test('SYNGRISI_AI_KEY does not override OPENAI_API_KEY for openai type', () => {
+    const result = mergeProviderConfig(
+        { type: 'openai' },
+        { OPENAI_API_KEY: 'sk-openai', SYNGRISI_AI_KEY: 'generic-key' },
+    );
+    assert.equal(result?.apiKey, 'sk-openai');
+});
+
+test('cfg.apiKey used when no env keys', () => {
+    const result = mergeProviderConfig({ type: 'openai', apiKey: 'db-key' }, {});
+    assert.equal(result?.apiKey, 'db-key');
+});
+
+test('empty-string env values treated as absent, cfg.apiKey wins', () => {
+    const result = mergeProviderConfig(
+        { type: 'openai', apiKey: 'db-key' },
+        { OPENAI_API_KEY: '', SYNGRISI_AI_KEY: '', OPENAI_API_BASE_URL: '' },
+    );
+    assert.equal(result?.apiKey, 'db-key');
+    assert.equal(result?.baseUrl, undefined);
+});
+
+test('missing type defaults to openai', () => {
+    const result = mergeProviderConfig({}, { OPENAI_API_KEY: 'sk-openai' });
+    assert.equal(result?.type, 'openai');
+    assert.equal(result?.apiKey, 'sk-openai');
+});
+
+test('passthrough of model/maxTokens/temperature/timeoutMs/fake* fields', () => {
+    const result = mergeProviderConfig(
+        {
+            type: 'anthropic',
+            model: 'claude-3-5-sonnet',
+            maxTokens: 512,
+            temperature: 0.2,
+            timeoutMs: 15000,
+            fakeVerdict: 'noise',
+            fakeConfidence: 8,
+            fakeReason: 'test reason',
+        },
+        {},
+    );
+    assert.equal(result?.model, 'claude-3-5-sonnet');
+    assert.equal(result?.maxTokens, 512);
+    assert.equal(result?.temperature, 0.2);
+    assert.equal(result?.timeoutMs, 15000);
+    assert.equal(result?.fakeVerdict, 'noise');
+    assert.equal(result?.fakeConfidence, 8);
+    assert.equal(result?.fakeReason, 'test reason');
+});

--- a/packages/syngrisi/src/server/services/triage/__tests__/retryPolicy.test.ts
+++ b/packages/syngrisi/src/server/services/triage/__tests__/retryPolicy.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { shouldRetryTriage } from '../retryPolicy';
+import { shouldRetryTriage, canBackgroundDrain } from '../retryPolicy';
 
 test('maxAttempts=3: retries after the first two failures, gives up after the third', () => {
     assert.equal(shouldRetryTriage(0, 3), true); // attempt 1 failed -> 2 attempts left, retry
@@ -10,4 +10,11 @@ test('maxAttempts=3: retries after the first two failures, gives up after the th
 
 test('maxAttempts=1: never retries (single attempt only)', () => {
     assert.equal(shouldRetryTriage(0, 1), false);
+});
+
+test('canBackgroundDrain: true only when both global and per-app triage are enabled', () => {
+    assert.equal(canBackgroundDrain(true, true), true);
+    assert.equal(canBackgroundDrain(true, false), false);
+    assert.equal(canBackgroundDrain(false, true), false);
+    assert.equal(canBackgroundDrain(false, false), false);
 });

--- a/packages/syngrisi/src/server/services/triage/__tests__/retryPolicy.test.ts
+++ b/packages/syngrisi/src/server/services/triage/__tests__/retryPolicy.test.ts
@@ -1,0 +1,13 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { shouldRetryTriage } from '../retryPolicy';
+
+test('maxAttempts=3: retries after the first two failures, gives up after the third', () => {
+    assert.equal(shouldRetryTriage(0, 3), true); // attempt 1 failed -> 2 attempts left, retry
+    assert.equal(shouldRetryTriage(1, 3), true); // attempt 2 failed -> retry
+    assert.equal(shouldRetryTriage(2, 3), false); // attempt 3 failed -> exactly 3 total attempts, give up
+});
+
+test('maxAttempts=1: never retries (single attempt only)', () => {
+    assert.equal(shouldRetryTriage(0, 1), false);
+});

--- a/packages/syngrisi/src/server/services/triage/config.ts
+++ b/packages/syngrisi/src/server/services/triage/config.ts
@@ -2,6 +2,7 @@
 import { appSettings } from '@settings';
 import { env } from '@/server/envConfig';
 import { TriageProviderConfig } from './types';
+import { mergeProviderConfig } from './mergeProviderConfig';
 
 // Global on/off: env override wins over DB (same precedence as other settings).
 export async function isTriageEnabled(): Promise<boolean> {
@@ -21,18 +22,9 @@ export async function getProviderConfig(): Promise<TriageProviderConfig | null> 
         try { cfg = JSON.parse(raw); } catch { /* ignore */ }
     }
 
-    const merged: TriageProviderConfig = {
-        type: (cfg.type as any) || 'openai',
-        baseUrl: cfg.baseUrl || env.OPENAI_API_BASE_URL || undefined,
-        apiKey: env.OPENAI_API_KEY || env.SYNGRISI_AI_KEY || cfg.apiKey || undefined,
-        model: cfg.model || undefined,
-        maxTokens: cfg.maxTokens,
-        temperature: cfg.temperature,
-        timeoutMs: cfg.timeoutMs,
-        fakeVerdict: cfg.fakeVerdict,
-        fakeConfidence: cfg.fakeConfidence,
-        fakeReason: cfg.fakeReason,
-    };
-    if (!merged.type) return null;
-    return merged;
+    return mergeProviderConfig(cfg, {
+        OPENAI_API_KEY: env.OPENAI_API_KEY,
+        OPENAI_API_BASE_URL: env.OPENAI_API_BASE_URL,
+        SYNGRISI_AI_KEY: env.SYNGRISI_AI_KEY,
+    });
 }

--- a/packages/syngrisi/src/server/services/triage/index.ts
+++ b/packages/syngrisi/src/server/services/triage/index.ts
@@ -3,11 +3,13 @@ import { Types } from 'mongoose';
 import { Check, App, Test, Suite } from '@models';
 import { accept } from '@services/check.service';
 import log from '@lib/logger';
+import { env } from '@/server/envConfig';
 import { buildTriageInput } from './analysis.service';
 import { buildSystemPrompt, substitutePlaceholders } from './prompt';
 import { createProvider } from './factory';
 import { getProviderConfig } from './config';
 import { shouldAutoAccept } from './policy';
+import { shouldRetryTriage } from './retryPolicy';
 import { getVerdictConfig, findVerdict, fallbackVerdict, UNKNOWN_VERDICT, CANCELLED_VERDICT } from './verdicts';
 import { TriageVerdictResult, VerdictDef } from './types';
 
@@ -58,13 +60,27 @@ export async function triageCheck(checkId: string): Promise<Record<string, unkno
 
     let result: TriageVerdictResult;
     let failed = false;
+    const priorAttempts = check.triage?.attempts ?? 0;
     try {
         const input = await buildTriageInput(checkId, verdicts, { systemPrompt, examples });
         if (!input) throw new Error(`check not found: ${checkId}`);
         result = await createProvider(cfg).classify(input);
     } catch (e) {
-        failed = true;
         log.warn(`triage failed for ${checkId}: ${e}`, { scope });
+        if (shouldRetryTriage(priorAttempts, env.SYNGRISI_AI_TRIAGE_MAX_ATTEMPTS)) {
+            // Transient provider failure (429 / timeout / cold local VLM) and attempts remain:
+            // re-queue for the scheduler instead of permanently burning the check on a failed verdict.
+            // ponytail: retries are spaced by the scheduler poll interval; no per-check backoff.
+            // Add exponential backoff keyed on triage.at if a persistently-down provider proves too chatty.
+            log.warn(`triage retry queued for ${checkId} (attempt ${priorAttempts + 1}/${env.SYNGRISI_AI_TRIAGE_MAX_ATTEMPTS})`, { scope });
+            return requeueCheck(checkId, {
+                attempts: priorAttempts + 1,
+                failed: false,
+                reason: 'triage failed, will retry',
+                at: new Date(),
+            });
+        }
+        failed = true;
         const fb = fallbackVerdict(verdicts);
         result = { verdict: fb.key, confidence: 0, reason: 'triage failed', model: cfg.model ?? cfg.type };
     }
@@ -88,6 +104,7 @@ export async function triageCheck(checkId: string): Promise<Record<string, unkno
         color: def?.color ?? 'gray',
         icon: def?.icon,
     };
+    if (failed) triage.attempts = priorAttempts + 1; // observability: total attempts made before giving up
 
     // Apply per-project auto-accept policy (verdict flags + policy allowlist + threshold).
     // Uses the model's real verdict; below-threshold can't auto-accept anyway (confidence gate).
@@ -129,6 +146,25 @@ export async function cancelCheck(checkId: string): Promise<Record<string, unkno
     };
     await Check.findByIdAndUpdate(checkId, { $set: { triage } }).exec();
     await updateTestWorstVerdict(check.test, verdicts);
+    return triage;
+}
+
+// Put a check back into the scheduler's pending queue: the shared primitive behind the bulk
+// "restart" action (queue restart runs async via the background scheduler instead of blocking
+// the request) and the bounded-retry path in `triageCheck` (a transient provider failure with
+// attempts remaining). Overwrites the whole `triage` subdocument with `{ pending: true, ...extra }`
+// so `triage.verdict` no longer exists and `findUntriagedCheckIds` re-selects this check on the
+// next poll. `extra` lets the retry path stamp `attempts`/`reason`/`at` alongside `pending`.
+export async function requeueCheck(checkId: string, extra: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
+    const check: any = await Check.findById(checkId).exec();
+    if (!check) throw new Error(`check not found: ${checkId}`);
+    const triage = { pending: true, ...extra };
+    await Check.findByIdAndUpdate(checkId, { $set: { triage } }).exec();
+    // Kick the scheduler so analysis starts right away instead of waiting for the next poll.
+    // Lazy import avoids a module-load cycle (triageScheduler statically imports this module).
+    import('@lib/schedulers/triageScheduler')
+        .then((m) => m.triageScheduler.kick())
+        .catch((e) => log.warn(`triage kick failed for check ${checkId}: ${e}`, { scope }));
     return triage;
 }
 

--- a/packages/syngrisi/src/server/services/triage/index.ts
+++ b/packages/syngrisi/src/server/services/triage/index.ts
@@ -7,9 +7,9 @@ import { env } from '@/server/envConfig';
 import { buildTriageInput } from './analysis.service';
 import { buildSystemPrompt, substitutePlaceholders } from './prompt';
 import { createProvider } from './factory';
-import { getProviderConfig } from './config';
+import { getProviderConfig, isTriageEnabled } from './config';
 import { shouldAutoAccept } from './policy';
-import { shouldRetryTriage } from './retryPolicy';
+import { shouldRetryTriage, canBackgroundDrain } from './retryPolicy';
 import { getVerdictConfig, findVerdict, fallbackVerdict, UNKNOWN_VERDICT, CANCELLED_VERDICT } from './verdicts';
 import { TriageVerdictResult, VerdictDef } from './types';
 
@@ -67,7 +67,13 @@ export async function triageCheck(checkId: string): Promise<Record<string, unkno
         result = await createProvider(cfg).classify(input);
     } catch (e) {
         log.warn(`triage failed for ${checkId}: ${e}`, { scope });
-        if (shouldRetryTriage(priorAttempts, env.SYNGRISI_AI_TRIAGE_MAX_ATTEMPTS)) {
+        // Only take the requeue path when the background scheduler will actually drain the
+        // check again (global triage on AND this app's triage on) — otherwise a requeued check
+        // would sit as `{ pending: true }` forever, invisible to the scheduler's query. Fall
+        // through to the terminal failed-verdict path below instead.
+        const canRetry = shouldRetryTriage(priorAttempts, env.SYNGRISI_AI_TRIAGE_MAX_ATTEMPTS)
+            && canBackgroundDrain(await isTriageEnabled(), app?.triageEnabled === true);
+        if (canRetry) {
             // Transient provider failure (429 / timeout / cold local VLM) and attempts remain:
             // re-queue for the scheduler instead of permanently burning the check on a failed verdict.
             // ponytail: retries are spaced by the scheduler poll interval; no per-check backoff.
@@ -160,6 +166,11 @@ export async function requeueCheck(checkId: string, extra: Record<string, unknow
     if (!check) throw new Error(`check not found: ${checkId}`);
     const triage = { pending: true, ...extra };
     await Check.findByIdAndUpdate(checkId, { $set: { triage } }).exec();
+    // The check's `triage.verdict` is gone now, so the parent test's cached worst verdict may be
+    // stale (same reason `cancelCheck` refreshes it) — recompute it the same way.
+    const app: any = await App.findById(check.app).exec();
+    const verdicts = getVerdictConfig(app);
+    await updateTestWorstVerdict(check.test, verdicts);
     // Kick the scheduler so analysis starts right away instead of waiting for the next poll.
     // Lazy import avoids a module-load cycle (triageScheduler statically imports this module).
     import('@lib/schedulers/triageScheduler')

--- a/packages/syngrisi/src/server/services/triage/mergeProviderConfig.ts
+++ b/packages/syngrisi/src/server/services/triage/mergeProviderConfig.ts
@@ -1,0 +1,33 @@
+import { TriageProviderConfig } from './types';
+
+// Env values relevant to provider config. OPENAI_* are OpenAI-specific and must
+// only apply when the provider type is 'openai' (or unset -> defaults to openai).
+export interface TriageEnv {
+    OPENAI_API_KEY?: string;
+    OPENAI_API_BASE_URL?: string;
+    SYNGRISI_AI_KEY?: string;   // generic env key override, any provider
+}
+
+// Merge DB-stored provider config with env overrides. Returns null if no usable type.
+export function mergeProviderConfig(
+    cfg: Partial<TriageProviderConfig>,
+    env: TriageEnv,
+): TriageProviderConfig | null {
+    const type = cfg.type || 'openai';
+    const isOpenAI = type === 'openai';
+
+    const merged: TriageProviderConfig = {
+        type,
+        baseUrl: cfg.baseUrl || (isOpenAI ? env.OPENAI_API_BASE_URL : undefined) || undefined,
+        apiKey: (isOpenAI ? env.OPENAI_API_KEY : undefined) || env.SYNGRISI_AI_KEY || cfg.apiKey || undefined,
+        model: cfg.model || undefined,
+        maxTokens: cfg.maxTokens,
+        temperature: cfg.temperature,
+        timeoutMs: cfg.timeoutMs,
+        fakeVerdict: cfg.fakeVerdict,
+        fakeConfidence: cfg.fakeConfidence,
+        fakeReason: cfg.fakeReason,
+    };
+    if (!merged.type) return null;
+    return merged;
+}

--- a/packages/syngrisi/src/server/services/triage/providers/anthropic.provider.ts
+++ b/packages/syngrisi/src/server/services/triage/providers/anthropic.provider.ts
@@ -49,7 +49,9 @@ export class AnthropicProvider implements TriageProvider {
             signal: AbortSignal.timeout(this.cfg.timeoutMs ?? 120000),
         });
         if (!resp.ok) {
-            throw new Error(`Anthropic provider HTTP ${resp.status}: ${await resp.text()}`);
+            // Do not reflect the upstream response body — cfg.baseUrl is user-controlled
+            // and this error is surfaced back to the caller (SSRF info-disclosure risk).
+            throw new Error(`Anthropic provider HTTP ${resp.status}`);
         }
         const data: any = await resp.json();
         const content = Array.isArray(data?.content)
@@ -72,7 +74,9 @@ export class AnthropicProvider implements TriageProvider {
             body: JSON.stringify({ model, max_tokens: 1, messages: [{ role: 'user', content: 'ping' }] }),
             signal: AbortSignal.timeout(15000),
         });
-        if (!resp.ok) throw new Error(`Anthropic provider HTTP ${resp.status}: ${await resp.text()}`);
+        // Do not reflect the upstream response body — cfg.baseUrl is user-controlled
+        // and this error is surfaced back to the caller (SSRF info-disclosure risk).
+        if (!resp.ok) throw new Error(`Anthropic provider HTTP ${resp.status}`);
         return { model };
     }
 }

--- a/packages/syngrisi/src/server/services/triage/providers/gemini.provider.ts
+++ b/packages/syngrisi/src/server/services/triage/providers/gemini.provider.ts
@@ -38,7 +38,9 @@ export class GeminiProvider implements TriageProvider {
             signal: AbortSignal.timeout(this.cfg.timeoutMs ?? 120000),
         });
         if (!resp.ok) {
-            throw new Error(`Gemini provider HTTP ${resp.status}: ${await resp.text()}`);
+            // Do not reflect the upstream response body — cfg.baseUrl is user-controlled
+            // and this error is surfaced back to the caller (SSRF info-disclosure risk).
+            throw new Error(`Gemini provider HTTP ${resp.status}`);
         }
         const data: any = await resp.json();
         const content = data?.candidates?.[0]?.content?.parts?.map((p: any) => p.text || '').join('') ?? '';
@@ -52,7 +54,9 @@ export class GeminiProvider implements TriageProvider {
         const resp = await fetch(`${baseUrl}/v1beta/models/${model}?key=${this.cfg.apiKey ?? ''}`, {
             signal: AbortSignal.timeout(15000),
         });
-        if (!resp.ok) throw new Error(`Gemini provider HTTP ${resp.status}: ${await resp.text()}`);
+        // Do not reflect the upstream response body — cfg.baseUrl is user-controlled
+        // and this error is surfaced back to the caller (SSRF info-disclosure risk).
+        if (!resp.ok) throw new Error(`Gemini provider HTTP ${resp.status}`);
         return { model };
     }
 }

--- a/packages/syngrisi/src/server/services/triage/providers/openai.provider.ts
+++ b/packages/syngrisi/src/server/services/triage/providers/openai.provider.ts
@@ -47,7 +47,9 @@ export class OpenAIProvider implements TriageProvider {
             signal: AbortSignal.timeout(this.cfg.timeoutMs ?? 120000),
         });
         if (!resp.ok) {
-            throw new Error(`OpenAI provider HTTP ${resp.status}: ${await resp.text()}`);
+            // Do not reflect the upstream response body — cfg.baseUrl is user-controlled
+            // and this error is surfaced back to the caller (SSRF info-disclosure risk).
+            throw new Error(`OpenAI provider HTTP ${resp.status}`);
         }
         const data: any = await resp.json();
         const msg = data?.choices?.[0]?.message ?? {};
@@ -64,7 +66,9 @@ export class OpenAIProvider implements TriageProvider {
             headers: { ...(this.cfg.apiKey ? { Authorization: `Bearer ${this.cfg.apiKey}` } : {}) },
             signal: AbortSignal.timeout(15000),
         });
-        if (!resp.ok) throw new Error(`OpenAI provider HTTP ${resp.status}: ${await resp.text()}`);
+        // Do not reflect the upstream response body — cfg.baseUrl is user-controlled
+        // and this error is surfaced back to the caller (SSRF info-disclosure risk).
+        if (!resp.ok) throw new Error(`OpenAI provider HTTP ${resp.status}`);
         const data: any = await resp.json();
         const ids = (data?.data ?? []).map((m: any) => m.id);
         if (ids.length && !ids.includes(model)) {

--- a/packages/syngrisi/src/server/services/triage/retryPolicy.ts
+++ b/packages/syngrisi/src/server/services/triage/retryPolicy.ts
@@ -1,0 +1,14 @@
+// Given how many attempts have already failed and the max, decide whether to
+// re-queue for another background attempt (true) or give up and stamp the
+// failed verdict (false).
+//
+// Arithmetic: `priorAttempts` counts attempts that have already failed (0 before
+// the very first try). The attempt that just failed is number `priorAttempts + 1`.
+// Retry while that count is still below `maxAttempts`, so exactly `maxAttempts`
+// total attempts happen before giving up. E.g. maxAttempts=3:
+//   attempt 1 fails (priorAttempts=0) -> 0+1=1 < 3 -> retry
+//   attempt 2 fails (priorAttempts=1) -> 1+1=2 < 3 -> retry
+//   attempt 3 fails (priorAttempts=2) -> 2+1=3 < 3 is false -> give up (3 attempts made)
+export function shouldRetryTriage(priorAttempts: number, maxAttempts: number): boolean {
+    return priorAttempts + 1 < maxAttempts;
+}

--- a/packages/syngrisi/src/server/services/triage/retryPolicy.ts
+++ b/packages/syngrisi/src/server/services/triage/retryPolicy.ts
@@ -12,3 +12,10 @@
 export function shouldRetryTriage(priorAttempts: number, maxAttempts: number): boolean {
     return priorAttempts + 1 < maxAttempts;
 }
+
+// The retry path re-queues a check for the background scheduler, which only drains
+// checks when global triage is enabled AND the check's project has per-project triage on.
+// If neither, a re-queued check would never be processed — so only retry when drainable.
+export function canBackgroundDrain(globalEnabled: boolean, appTriageEnabled: boolean): boolean {
+    return globalEnabled && appTriageEnabled;
+}

--- a/packages/syngrisi/src/server/utils/__tests__/escapeHtml.test.ts
+++ b/packages/syngrisi/src/server/utils/__tests__/escapeHtml.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { escapeHtml } from '../escapeHtml';
+
+test('escapes all five special characters', () => {
+    assert.equal(escapeHtml('&'), '&amp;');
+    assert.equal(escapeHtml('<'), '&lt;');
+    assert.equal(escapeHtml('>'), '&gt;');
+    assert.equal(escapeHtml('"'), '&quot;');
+    assert.equal(escapeHtml("'"), '&#39;');
+});
+
+test('leaves a plain string untouched', () => {
+    assert.equal(escapeHtml('hello world 123'), 'hello world 123');
+});
+
+test('converts null and undefined to an empty string', () => {
+    assert.equal(escapeHtml(null), '');
+    assert.equal(escapeHtml(undefined), '');
+});
+
+test('neutralizes a realistic XSS payload', () => {
+    assert.equal(
+        escapeHtml('<img src=x onerror=alert(1)>'),
+        '&lt;img src=x onerror=alert(1)&gt;'
+    );
+});

--- a/packages/syngrisi/src/server/utils/escapeHtml.ts
+++ b/packages/syngrisi/src/server/utils/escapeHtml.ts
@@ -1,0 +1,5 @@
+// Escape a value for safe interpolation into HTML text and double-quoted attributes.
+export const escapeHtml = (value: unknown): string =>
+    String(value ?? '').replace(/[&<>"']/g, (ch) => (
+        { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch] as string
+    ));

--- a/packages/syngrisi/src/server/utils/index.ts
+++ b/packages/syngrisi/src/server/utils/index.ts
@@ -21,6 +21,7 @@ export { createTable } from './stringTable';
 export { colors } from './colors';
 export { default as HttpStatus } from './httpStatus';
 export { cookieParser } from './cookieParser';
+export { escapeHtml } from './escapeHtml';
 
 export {
     pick,

--- a/packages/syngrisi/src/ui-app/admin/components/AI/AdminAI.tsx
+++ b/packages/syngrisi/src/ui-app/admin/components/AI/AdminAI.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import {
     ScrollArea, Box, Title, Paper, Select, Switch, NumberInput, MultiSelect, Button, Group, Table,
     TextInput, Checkbox, ActionIcon, Text, Divider, ColorInput, Loader, Badge, Textarea, FileButton, Image, Stack, Tabs,
+    Popover,
 } from '@mantine/core';
 import { IconTrash, IconPlus, IconPhoto } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
@@ -85,32 +86,96 @@ function PerProjectTriage() {
     const [simGate, setSimGate] = useState<number>(0.32);
     const [saving, setSaving] = useState(false);
 
+    // Client-only stable render keys for the editable verdict/example rows, kept in a parallel
+    // array so an `id` is never merged into the objects that get sent to the server (the
+    // triageVerdicts payload is validated with a `.strict()` zod schema — an extra field would
+    // fail saving).
+    const [verdictRowIds, setVerdictRowIds] = useState<string[]>(() => DEFAULT_VERDICTS.map(() => crypto.randomUUID()));
+    const [exampleRowIds, setExampleRowIds] = useState<string[]>([]);
+
+    // Snapshot of the config as it was loaded for the currently selected project, used to detect
+    // unsaved edits before silently switching projects. `null` = nothing loaded yet.
+    const [loadedSnapshot, setLoadedSnapshot] = useState<string | null>(null);
+    const [pendingAppId, setPendingAppId] = useState<string | null>(null);
+    const [confirmSwitchOpened, setConfirmSwitchOpened] = useState(false);
+
+    const currentSnapshot = useMemo(
+        () => JSON.stringify({ enabled, mode, threshold, allow, verdicts, prompt, examples, simGate }),
+        [enabled, mode, threshold, allow, verdicts, prompt, examples, simGate],
+    );
+    const isDirty = loadedSnapshot !== null && currentSnapshot !== loadedSnapshot;
+
     useEffect(() => {
         if (!selected) return;
-        setEnabled(selected.triageEnabled === true);
-        setMode(selected.triagePolicy?.policy || 'suggest');
-        setThreshold(typeof selected.triagePolicy?.autoAcceptThreshold === 'number' ? selected.triagePolicy.autoAcceptThreshold : 9);
-        setAllow(selected.triagePolicy?.autoAcceptVerdicts || ['intended_change', 'noise']);
+        const nextEnabled = selected.triageEnabled === true;
+        const nextMode = selected.triagePolicy?.policy || 'suggest';
+        const nextThreshold = typeof selected.triagePolicy?.autoAcceptThreshold === 'number' ? selected.triagePolicy.autoAcceptThreshold : 9;
+        const nextAllow = selected.triagePolicy?.autoAcceptVerdicts || ['intended_change', 'noise'];
         const vlist = Array.isArray(selected.triageVerdicts) && selected.triageVerdicts.length ? selected.triageVerdicts : DEFAULT_VERDICTS;
-        setVerdicts(vlist);
         // Always show the effective prompt: the project's override, or the generated default.
-        setPrompt(selected.triagePrompt ? selected.triagePrompt : buildDefaultPrompt(vlist));
-        setExamples(Array.isArray(selected.triageExamples) ? selected.triageExamples : []);
-        setSimGate(typeof selected.changeSimGate === 'number' ? selected.changeSimGate : 0.32);
+        const nextPrompt = selected.triagePrompt ? selected.triagePrompt : buildDefaultPrompt(vlist);
+        const nextExamples = Array.isArray(selected.triageExamples) ? selected.triageExamples : [];
+        const nextSimGate = typeof selected.changeSimGate === 'number' ? selected.changeSimGate : 0.32;
+
+        setEnabled(nextEnabled);
+        setMode(nextMode);
+        setThreshold(nextThreshold);
+        setAllow(nextAllow);
+        setVerdicts(vlist);
+        setPrompt(nextPrompt);
+        setExamples(nextExamples);
+        setSimGate(nextSimGate);
+        setVerdictRowIds(vlist.map(() => crypto.randomUUID()));
+        setExampleRowIds(nextExamples.map(() => crypto.randomUUID()));
+        setLoadedSnapshot(JSON.stringify({
+            enabled: nextEnabled, mode: nextMode, threshold: nextThreshold, allow: nextAllow, verdicts: vlist, prompt: nextPrompt, examples: nextExamples, simGate: nextSimGate,
+        }));
     }, [selected]);
+
+    const handleProjectChange = (value: string | null) => {
+        if (isDirty && appId) {
+            setPendingAppId(value);
+            setConfirmSwitchOpened(true);
+            return;
+        }
+        setAppId(value);
+    };
+
+    const confirmProjectSwitch = () => {
+        setAppId(pendingAppId);
+        setPendingAppId(null);
+        setConfirmSwitchOpened(false);
+    };
+
+    const cancelProjectSwitch = () => {
+        setPendingAppId(null);
+        setConfirmSwitchOpened(false);
+    };
 
     const addExample = (file: File | null) => {
         if (!file) return;
         const reader = new FileReader();
-        reader.onload = () => setExamples((ex) => [...ex, { verdict: verdicts[0]?.key || '', image: String(reader.result), note: '' }]);
+        reader.onload = () => {
+            setExamples((ex) => [...ex, { verdict: verdicts[0]?.key || '', image: String(reader.result), note: '' }]);
+            setExampleRowIds((ids) => [...ids, crypto.randomUUID()]);
+        };
         reader.readAsDataURL(file); // stored as a data URL (data:image/...;base64,...)
     };
     const updateExample = (i: number, patch: Partial<Example>) => setExamples((ex) => ex.map((row, idx) => (idx === i ? { ...row, ...patch } : row)));
-    const removeExample = (i: number) => setExamples((ex) => ex.filter((_, idx) => idx !== i));
+    const removeExample = (i: number) => {
+        setExamples((ex) => ex.filter((_, idx) => idx !== i));
+        setExampleRowIds((ids) => ids.filter((_, idx) => idx !== i));
+    };
 
     const update = (i: number, patch: Partial<Verdict>) => setVerdicts((v) => v.map((row, idx) => (idx === i ? { ...row, ...patch } : row)));
-    const remove = (i: number) => setVerdicts((v) => v.filter((_, idx) => idx !== i));
-    const add = () => setVerdicts((v) => [...v, { key: '', label: '', color: 'blue', icon: 'flag', severity: v.length + 1, autoAcceptable: false }]);
+    const remove = (i: number) => {
+        setVerdicts((v) => v.filter((_, idx) => idx !== i));
+        setVerdictRowIds((ids) => ids.filter((_, idx) => idx !== i));
+    };
+    const add = () => {
+        setVerdicts((v) => [...v, { key: '', label: '', color: 'blue', icon: 'flag', severity: v.length + 1, autoAcceptable: false }]);
+        setVerdictRowIds((ids) => [...ids, crypto.randomUUID()]);
+    };
 
     const save = async () => {
         if (!appId) return;
@@ -153,15 +218,36 @@ function PerProjectTriage() {
                     docHref="https://github.com/syngrisi/syngrisi/blob/main/packages/syngrisi/AI_TRIAGE.md"
                 />
             </Group>
-            <Select
-                label="Project"
-                placeholder={appsQuery.isLoading ? 'loading…' : 'select a project'}
-                value={appId}
-                onChange={setAppId}
-                data-test="ai-project-select"
-                data={apps.map((a) => ({ value: a._id, label: a.name }))}
-                mb="md"
-            />
+            <Popover
+                opened={confirmSwitchOpened}
+                onChange={(opened) => { setConfirmSwitchOpened(opened); if (!opened) setPendingAppId(null); }}
+                position="bottom-start"
+                withArrow
+                shadow="md"
+                closeOnClickOutside
+                closeOnEscape
+            >
+                <Popover.Target>
+                    <Select
+                        label="Project"
+                        placeholder={appsQuery.isLoading ? 'loading…' : 'select a project'}
+                        value={appId}
+                        onChange={handleProjectChange}
+                        data-test="ai-project-select"
+                        data={apps.map((a) => ({ value: a._id, label: a.name }))}
+                        mb="md"
+                    />
+                </Popover.Target>
+                <Popover.Dropdown>
+                    <Stack gap="xs">
+                        <Text size="sm">Discard unsaved changes to this project&apos;s AI Triage config and switch project?</Text>
+                        <Group gap="xs">
+                            <Button size="xs" variant="default" onClick={cancelProjectSwitch} data-test="ai-project-switch-cancel-button">Cancel</Button>
+                            <Button size="xs" color="red" onClick={confirmProjectSwitch} data-test="ai-project-switch-confirm-button">Discard and switch</Button>
+                        </Group>
+                    </Stack>
+                </Popover.Dropdown>
+            </Popover>
             {!appId ? <Text size="sm" c="dimmed">Select a project to configure its verdicts and policy.</Text> : (
                 <>
                     <Switch label="Auto-triage for this project" description="Automatically classify new failed checks in this project. Requires AI Triage enabled instance-wide (Settings tab)." checked={enabled} onChange={(e) => setEnabled(e.currentTarget.checked)} data-test="ai-project-enabled" mb="md" styles={{ description: { maxWidth: 420 } }} />
@@ -193,8 +279,7 @@ function PerProjectTriage() {
                         </Table.Thead>
                         <Table.Tbody>
                             {verdicts.map((v, i) => (
-                                // eslint-disable-next-line react/no-array-index-key
-                                <Table.Tr key={i} data-test="ai-verdict-row">
+                                <Table.Tr key={verdictRowIds[i] ?? i} data-test="ai-verdict-row">
                                     <Table.Td><TextInput value={v.key} onChange={(e) => update(i, { key: e.currentTarget.value })} placeholder="key" /></Table.Td>
                                     <Table.Td><TextInput value={v.label} onChange={(e) => update(i, { label: e.currentTarget.value })} placeholder="Label" /></Table.Td>
                                     <Table.Td>
@@ -264,8 +349,7 @@ function PerProjectTriage() {
                     <Text size="sm" fw={500} mb={4}>Few-shot examples</Text>
                     <Stack gap="xs" data-test="ai-examples">
                         {examples.map((ex, i) => (
-                            // eslint-disable-next-line react/no-array-index-key
-                            <Group key={i} gap="xs" align="center" data-test="ai-example-row">
+                            <Group key={exampleRowIds[i] ?? i} gap="xs" align="center" data-test="ai-example-row">
                                 <Image src={ex.image} w={64} h={40} fit="contain" radius="sm" />
                                 <Select
                                     value={ex.verdict}

--- a/packages/syngrisi/src/ui-app/admin/components/AI/AdminAI.tsx
+++ b/packages/syngrisi/src/ui-app/admin/components/AI/AdminAI.tsx
@@ -71,7 +71,9 @@ Rules:
 }
 
 function PerProjectTriage() {
-    const appsQuery = useQuery({ queryKey: ['apps-for-triage'], queryFn: () => GenericService.get('app', {}, { limit: '0' }) });
+    // No window-focus refetch: a background refetch swaps the `selected` object and the [selected]
+    // effect would silently overwrite unsaved verdict/example edits (the dirty-guard only covers manual switches).
+    const appsQuery = useQuery({ queryKey: ['apps-for-triage'], queryFn: () => GenericService.get('app', {}, { limit: '0' }), refetchOnWindowFocus: false });
     const apps: any[] = appsQuery.data?.results || [];
     const [appId, setAppId] = useState<string | null>(null);
     const selected = useMemo(() => apps.find((a) => a._id === appId), [apps, appId]);

--- a/packages/syngrisi/src/ui-app/admin/components/AI/HelpDoc.tsx
+++ b/packages/syngrisi/src/ui-app/admin/components/AI/HelpDoc.tsx
@@ -32,7 +32,7 @@ export function HelpDoc({ title, lines, docHref, dataTest = 'help-doc' }: Props)
                 <Stack gap={6} data-test="help-doc-popover">
                     <Text size="sm" fw={600}>{title}</Text>
                     {lines.map((l) => <Text key={l} size="xs" c="dimmed">{l}</Text>)}
-                    {docHref && <Anchor href={docHref} target="_blank" size="xs">Open full documentation →</Anchor>}
+                    {docHref && <Anchor href={docHref} target="_blank" rel="noopener noreferrer" size="xs">Open full documentation →</Anchor>}
                 </Stack>
             </Popover.Dropdown>
         </Popover>

--- a/packages/syngrisi/src/ui-app/admin/components/DataManagement/AdminDataManagement.tsx
+++ b/packages/syngrisi/src/ui-app/admin/components/DataManagement/AdminDataManagement.tsx
@@ -10,6 +10,7 @@ import {
     Group,
     Loader,
     Paper,
+    Popover,
     Progress,
     ScrollArea,
     SimpleGrid,
@@ -79,6 +80,11 @@ export default function AdminDataManagement() {
     const [skipExisting, setSkipExisting] = useState(true);
     const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
     const [jobLog, setJobLog] = useState('');
+    // Popover-based confirm state, following the same confirm-before-fire pattern
+    // used by ActionPopoverIcon elsewhere in the app (Popover.Target opens on click,
+    // the mutation only fires from the confirm button in Popover.Dropdown).
+    const [dbRestoreConfirmOpened, setDbRestoreConfirmOpened] = useState(false);
+    const [deleteConfirmJobId, setDeleteConfirmJobId] = useState<string | null>(null);
 
     const jobsQuery = useQuery({
         queryKey: ['admin-data-jobs'],
@@ -255,9 +261,44 @@ export default function AdminDataManagement() {
                             value={dbRestoreFile}
                             onChange={setDbRestoreFile}
                         />
-                        <Button color="red" onClick={() => dbRestoreMutation.mutate()} loading={dbRestoreMutation.isPending} disabled={isBusy || !dbRestoreFile}>
-                            Upload and Restore Database
-                        </Button>
+                        <Popover
+                            opened={dbRestoreConfirmOpened}
+                            onChange={setDbRestoreConfirmOpened}
+                            position="bottom"
+                            withArrow
+                            shadow="md"
+                            closeOnClickOutside
+                            closeOnEscape
+                        >
+                            <Popover.Target>
+                                <Button
+                                    color="red"
+                                    onClick={() => setDbRestoreConfirmOpened((opened) => !opened)}
+                                    loading={dbRestoreMutation.isPending}
+                                    disabled={isBusy || !dbRestoreFile}
+                                >
+                                    Upload and Restore Database
+                                </Button>
+                            </Popover.Target>
+                            <Popover.Dropdown>
+                                <Stack gap="xs">
+                                    <Text size="sm">
+                                        This will drop the current database and replace it with the uploaded archive.
+                                        This cannot be undone.
+                                    </Text>
+                                    <Button
+                                        color="red"
+                                        data-test="db-restore-confirm-button"
+                                        onClick={() => {
+                                            setDbRestoreConfirmOpened(false);
+                                            dbRestoreMutation.mutate();
+                                        }}
+                                    >
+                                        Confirm Restore
+                                    </Button>
+                                </Stack>
+                            </Popover.Dropdown>
+                        </Popover>
                     </Stack>
                 </Paper>
 
@@ -321,81 +362,118 @@ export default function AdminDataManagement() {
                         </tr>
                     </thead>
                     <tbody>
-                        {(jobsQuery.data?.jobs || []).map((job) => (
-                            <tr key={job.id} onClick={() => setSelectedJobId(job.id)} style={{ cursor: 'pointer' }}>
-                                <td>
-                                    <Text fw={500}>{getJobLabel(job.type)}</Text>
-                                    <Text size="xs" c="dimmed"><Code>{job.id}</Code></Text>
-                                </td>
-                                <td>
-                                    <Badge color={getStatusColor(job.status)}>{job.status}</Badge>
-                                    <Text size="xs" c="dimmed">{job.message}</Text>
-                                </td>
-                                <td style={{ minWidth: 180 }}>
-                                    <Progress value={job.progress.percent || 0} size="lg" />
-                                    <Text size="xs" c="dimmed">
-                                        {job.progress.stage}
-                                        {typeof job.progress.current === 'number' && typeof job.progress.total === 'number'
-                                            ? ` (${job.progress.current}/${job.progress.total})`
-                                            : ''}
-                                    </Text>
-                                </td>
-                                <td>
-                                    <Text size="sm">Archive: {formatBytes(job.stats.archiveSizeBytes)}</Text>
-                                    {'processedFiles' in job.stats && (
+                        {(jobsQuery.data?.jobs || []).map((job) => {
+                            const jobBusy = (cancelMutation.isPending && cancelMutation.variables === job.id)
+                                || (deleteMutation.isPending && deleteMutation.variables === job.id);
+                            return (
+                                <tr key={job.id} onClick={() => setSelectedJobId(job.id)} style={{ cursor: 'pointer' }}>
+                                    <td>
+                                        <Text fw={500}>{getJobLabel(job.type)}</Text>
+                                        <Text size="xs" c="dimmed"><Code>{job.id}</Code></Text>
+                                    </td>
+                                    <td>
+                                        <Badge color={getStatusColor(job.status)}>{job.status}</Badge>
+                                        <Text size="xs" c="dimmed">{job.message}</Text>
+                                    </td>
+                                    <td style={{ minWidth: 180 }}>
+                                        <Progress value={job.progress.percent || 0} size="lg" />
                                         <Text size="xs" c="dimmed">
-                                            Processed: {job.stats.processedFiles || 0}
-                                            {job.stats.importedFiles !== undefined ? `, imported ${job.stats.importedFiles}` : ''}
-                                            {job.stats.skippedFiles !== undefined ? `, skipped ${job.stats.skippedFiles}` : ''}
-                                            {job.stats.errorFiles !== undefined ? `, errors ${job.stats.errorFiles}` : ''}
+                                            {job.progress.stage}
+                                            {typeof job.progress.current === 'number' && typeof job.progress.total === 'number'
+                                                ? ` (${job.progress.current}/${job.progress.total})`
+                                                : ''}
                                         </Text>
-                                    )}
-                                </td>
-                                <td>
-                                    <Group gap="xs">
-                                        {job.downloadAvailable && (
-                                            <Button
-                                                component="a"
-                                                href={adminDataService.getDownloadUrl(job.id)}
-                                                variant="outline"
-                                                size="xs"
-                                                leftIcon={<IconDownload size={14} />}
-                                            >
-                                                Download
-                                            </Button>
+                                    </td>
+                                    <td>
+                                        <Text size="sm">Archive: {formatBytes(job.stats.archiveSizeBytes)}</Text>
+                                        {'processedFiles' in job.stats && (
+                                            <Text size="xs" c="dimmed">
+                                                Processed: {job.stats.processedFiles || 0}
+                                                {job.stats.importedFiles !== undefined ? `, imported ${job.stats.importedFiles}` : ''}
+                                                {job.stats.skippedFiles !== undefined ? `, skipped ${job.stats.skippedFiles}` : ''}
+                                                {job.stats.errorFiles !== undefined ? `, errors ${job.stats.errorFiles}` : ''}
+                                            </Text>
                                         )}
-                                        {ACTIVE_STATUSES.has(job.status) && (
-                                            <Button
-                                                color="red"
-                                                variant="outline"
-                                                size="xs"
-                                                leftIcon={<IconX size={14} />}
-                                                onClick={(event) => {
-                                                    event.stopPropagation();
-                                                    cancelMutation.mutate(job.id);
-                                                }}
-                                            >
-                                                Cancel
-                                            </Button>
-                                        )}
-                                        {!ACTIVE_STATUSES.has(job.status) && (
-                                            <Button
-                                                color="gray"
-                                                variant="outline"
-                                                size="xs"
-                                                leftIcon={<IconTrash size={14} />}
-                                                onClick={(event) => {
-                                                    event.stopPropagation();
-                                                    deleteMutation.mutate(job.id);
-                                                }}
-                                            >
-                                                Delete
-                                            </Button>
-                                        )}
-                                    </Group>
-                                </td>
-                            </tr>
-                        ))}
+                                    </td>
+                                    <td>
+                                        <Group gap="xs">
+                                            {job.downloadAvailable && (
+                                                <Button
+                                                    component="a"
+                                                    href={adminDataService.getDownloadUrl(job.id)}
+                                                    variant="outline"
+                                                    size="xs"
+                                                    leftIcon={<IconDownload size={14} />}
+                                                >
+                                                    Download
+                                                </Button>
+                                            )}
+                                            {ACTIVE_STATUSES.has(job.status) && (
+                                                <Button
+                                                    color="red"
+                                                    variant="outline"
+                                                    size="xs"
+                                                    leftIcon={<IconX size={14} />}
+                                                    loading={cancelMutation.isPending && cancelMutation.variables === job.id}
+                                                    disabled={jobBusy}
+                                                    onClick={(event) => {
+                                                        event.stopPropagation();
+                                                        cancelMutation.mutate(job.id);
+                                                    }}
+                                                >
+                                                    Cancel
+                                                </Button>
+                                            )}
+                                            {!ACTIVE_STATUSES.has(job.status) && (
+                                                <Popover
+                                                    opened={deleteConfirmJobId === job.id}
+                                                    onChange={(opened) => setDeleteConfirmJobId(opened ? job.id : null)}
+                                                    position="bottom"
+                                                    withArrow
+                                                    shadow="md"
+                                                    closeOnClickOutside
+                                                    closeOnEscape
+                                                >
+                                                    <Popover.Target>
+                                                        <Button
+                                                            color="gray"
+                                                            variant="outline"
+                                                            size="xs"
+                                                            leftIcon={<IconTrash size={14} />}
+                                                            loading={deleteMutation.isPending && deleteMutation.variables === job.id}
+                                                            disabled={jobBusy}
+                                                            onClick={(event) => {
+                                                                event.stopPropagation();
+                                                                setDeleteConfirmJobId(job.id);
+                                                            }}
+                                                        >
+                                                            Delete
+                                                        </Button>
+                                                    </Popover.Target>
+                                                    <Popover.Dropdown>
+                                                        <Stack gap="xs">
+                                                            <Text size="sm">Delete this job&apos;s data? This cannot be undone.</Text>
+                                                            <Button
+                                                                color="red"
+                                                                size="xs"
+                                                                data-test="job-delete-confirm-button"
+                                                                onClick={(event) => {
+                                                                    event.stopPropagation();
+                                                                    setDeleteConfirmJobId(null);
+                                                                    deleteMutation.mutate(job.id);
+                                                                }}
+                                                            >
+                                                                Confirm Delete
+                                                            </Button>
+                                                        </Stack>
+                                                    </Popover.Dropdown>
+                                                </Popover>
+                                            )}
+                                        </Group>
+                                    </td>
+                                </tr>
+                            );
+                        })}
                     </tbody>
                 </Table>
                 </div>

--- a/packages/syngrisi/src/ui-app/admin/components/Logs/RefreshActionIcon.tsx
+++ b/packages/syngrisi/src/ui-app/admin/components/Logs/RefreshActionIcon.tsx
@@ -11,7 +11,7 @@ function RefreshActionIcon({ newestItemsQuery, firstPageQuery }: Props) {
     const theme = useMantineTheme();
     const colorScheme = useComputedColorScheme();
     const newestItems = newestItemsQuery?.data?.results.length > 50 ? '50+' : newestItemsQuery?.data?.results.length;
-    const pluralCharset = newestItems > 1 ? 's' : '';
+    const pluralCharset = newestItemsQuery?.data?.results.length > 1 ? 's' : '';
     return (
         <ActionIcon
             color={colorScheme === 'dark' ? 'green.8' : 'green.6'}

--- a/packages/syngrisi/src/ui-app/admin/components/Logs/Table/InfinityScrollSkeleton.tsx
+++ b/packages/syngrisi/src/ui-app/admin/components/Logs/Table/InfinityScrollSkeleton.tsx
@@ -42,44 +42,34 @@ function InfinityScrollSkeleton({ infinityQuery, visibleFields, scrollRootRef }:
         };
     }, [scrollRootRef, root]);
 
-    // Scroll-based detection for loading more items
+    // Fallback auto-load for non-overflowing content.
+    // The primary fetch trigger for infinite scroll is ScrollArea's `onBottomReached`
+    // prop (see AdminLogsTable), which only ever fires from inside the viewport's
+    // native `scroll` event handler. If the loaded rows don't overflow the scroll
+    // container (scrollHeight <= clientHeight), the browser never dispatches a
+    // `scroll` event, so `onBottomReached` can structurally never fire and paging
+    // would stall. This effect covers exactly that gap; it does not duplicate
+    // `onBottomReached` (no scroll listener here) and only acts while there is no
+    // overflow to scroll.
     useEffect(() => {
         if (!root || infinityQuery === null) return;
+        if (!infinityQuery.hasNextPage || infinityQuery.isFetchingNextPage) return;
 
-        const checkShouldLoad = () => {
-            if (!root) return;
-            if (!infinityQuery.hasNextPage || infinityQuery.isFetchingNextPage) return;
-
-            const { scrollHeight, scrollTop, clientHeight } = root;
-
-            if (scrollHeight <= clientHeight + 5) {
-                // Content fits within viewport: fetch next page
-                infinityQuery.fetchNextPage();
-            } else {
-                // Content overflows: fetch if scrolled near bottom
-                const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
-                if (distanceFromBottom < 600) {
-                    infinityQuery.fetchNextPage();
-                }
-            }
-        };
-
-        const handleScroll = () => {
-            checkShouldLoad();
-        };
-
-        // Delay initial check to let DOM render
+        // Delay the check to let the DOM render before measuring.
         const rafId = requestAnimationFrame(() => {
             requestAnimationFrame(() => {
-                checkShouldLoad();
+                if (!root) return;
+                const { scrollHeight, clientHeight } = root;
+
+                if (scrollHeight <= clientHeight + 5) {
+                    // Content fits within viewport: fetch next page
+                    infinityQuery.fetchNextPage();
+                }
             });
         });
 
-        root.addEventListener('scroll', handleScroll, { passive: true });
-
         return () => {
             cancelAnimationFrame(rafId);
-            root.removeEventListener('scroll', handleScroll);
         };
     }, [root, infinityQuery?.hasNextPage, infinityQuery?.isFetchingNextPage]);
 

--- a/packages/syngrisi/src/ui-app/admin/components/Logs/Table/InfinityScrollSkeleton.tsx
+++ b/packages/syngrisi/src/ui-app/admin/components/Logs/Table/InfinityScrollSkeleton.tsx
@@ -42,34 +42,44 @@ function InfinityScrollSkeleton({ infinityQuery, visibleFields, scrollRootRef }:
         };
     }, [scrollRootRef, root]);
 
-    // Fallback auto-load for non-overflowing content.
-    // The primary fetch trigger for infinite scroll is ScrollArea's `onBottomReached`
-    // prop (see AdminLogsTable), which only ever fires from inside the viewport's
-    // native `scroll` event handler. If the loaded rows don't overflow the scroll
-    // container (scrollHeight <= clientHeight), the browser never dispatches a
-    // `scroll` event, so `onBottomReached` can structurally never fire and paging
-    // would stall. This effect covers exactly that gap; it does not duplicate
-    // `onBottomReached` (no scroll listener here) and only acts while there is no
-    // overflow to scroll.
+    // Scroll-based detection for loading more items
     useEffect(() => {
         if (!root || infinityQuery === null) return;
-        if (!infinityQuery.hasNextPage || infinityQuery.isFetchingNextPage) return;
 
-        // Delay the check to let the DOM render before measuring.
-        const rafId = requestAnimationFrame(() => {
-            requestAnimationFrame(() => {
-                if (!root) return;
-                const { scrollHeight, clientHeight } = root;
+        const checkShouldLoad = () => {
+            if (!root) return;
+            if (!infinityQuery.hasNextPage || infinityQuery.isFetchingNextPage) return;
 
-                if (scrollHeight <= clientHeight + 5) {
-                    // Content fits within viewport: fetch next page
+            const { scrollHeight, scrollTop, clientHeight } = root;
+
+            if (scrollHeight <= clientHeight + 5) {
+                // Content fits within viewport: fetch next page
+                infinityQuery.fetchNextPage();
+            } else {
+                // Content overflows: fetch if scrolled near bottom
+                const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
+                if (distanceFromBottom < 600) {
                     infinityQuery.fetchNextPage();
                 }
+            }
+        };
+
+        const handleScroll = () => {
+            checkShouldLoad();
+        };
+
+        // Delay initial check to let DOM render
+        const rafId = requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                checkShouldLoad();
             });
         });
 
+        root.addEventListener('scroll', handleScroll, { passive: true });
+
         return () => {
             cancelAnimationFrame(rafId);
+            root.removeEventListener('scroll', handleScroll);
         };
     }, [root, infinityQuery?.hasNextPage, infinityQuery?.isFetchingNextPage]);
 

--- a/packages/syngrisi/src/ui-app/admin/components/PluginSettings/AdminPluginSettings.tsx
+++ b/packages/syngrisi/src/ui-app/admin/components/PluginSettings/AdminPluginSettings.tsx
@@ -5,12 +5,13 @@
  */
 
 import * as React from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
     Table,
     Badge,
     Switch,
     TextInput,
+    NumberInput,
     Select,
     Button,
     Group,
@@ -62,29 +63,13 @@ interface PluginsResponse {
 }
 
 const fetchPlugins = async (): Promise<PluginsResponse> => {
-    console.log('[PluginSettings] fetchPlugins: Starting request to /v1/plugin-settings');
-    try {
-        const response = await fetch('/v1/plugin-settings', {
-            credentials: 'include', // Required for session-based authentication
-        });
-        console.log('[PluginSettings] fetchPlugins: Response received', {
-            status: response.status,
-            statusText: response.statusText,
-            redirected: response.redirected,
-            url: response.url,
-            type: response.type,
-        });
-        if (!response.ok) {
-            console.error('[PluginSettings] fetchPlugins: Response not OK', response.status);
-            throw new Error('Failed to fetch plugins');
-        }
-        const data = await response.json();
-        console.log('[PluginSettings] fetchPlugins: Data received', data);
-        return data;
-    } catch (error) {
-        console.error('[PluginSettings] fetchPlugins: Error caught', error);
-        throw error;
+    const response = await fetch('/v1/plugin-settings', {
+        credentials: 'include', // Required for session-based authentication
+    });
+    if (!response.ok) {
+        throw new Error('Failed to fetch plugins');
     }
+    return response.json();
 };
 
 const updatePluginSettings = async ({
@@ -127,6 +112,16 @@ function PluginSettingsForm({
     onUpdate: (settings: Record<string, unknown>) => void;
 }) {
     const [localSettings, setLocalSettings] = useState<Record<string, unknown>>(plugin.settings);
+
+    // Resync local settings when the server persists a new version.
+    // Keyed off `plugin.updatedAt` (the server-change signal) rather than
+    // `plugin.settings`, since react-query returns a fresh object reference
+    // on every window-focus refetch even when values are unchanged, which
+    // would otherwise clobber a user's in-progress edits mid-typing.
+    useEffect(() => {
+        setLocalSettings(plugin.settings);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [plugin.updatedAt]);
 
     const handleChange = (key: string, value: unknown) => {
         const newSettings = { ...localSettings, [key]: value };
@@ -201,12 +196,11 @@ function PluginSettingsForm({
                             )}
 
                             {field.type === 'number' && (
-                                <TextInput
+                                <NumberInput
                                     style={{ flex: 1 }}
-                                    type="number"
-                                    value={dbValue !== undefined ? String(dbValue) : ''}
+                                    value={dbValue !== undefined ? Number(dbValue) : ''}
                                     placeholder={effectiveValue?.value !== undefined ? String(effectiveValue.value) : `Enter ${field.label}`}
-                                    onChange={(e) => handleChange(field.key, parseFloat(e.currentTarget.value) || 0)}
+                                    onChange={(value) => handleChange(field.key, value === '' ? undefined : value)}
                                 />
                             )}
 

--- a/packages/syngrisi/src/ui-app/admin/components/Settings/AIProviderSettingsForm.tsx
+++ b/packages/syngrisi/src/ui-app/admin/components/Settings/AIProviderSettingsForm.tsx
@@ -5,6 +5,7 @@ import { GenericService, TriageService } from '@shared/services';
 import { errorMsg } from '@shared/utils';
 import { successMsg } from '@shared/utils/utils';
 import { HelpDoc } from '@admin/components/AI/HelpDoc';
+import { resolveTestApiKey } from './resolveTestApiKey';
 
 type ProviderValue = {
     type?: string;
@@ -74,7 +75,10 @@ export const AIProviderSettingsForm = ({ settings, refetch }: { settings: any[],
         setTesting(true);
         setTestResult(null);
         try {
-            const res = await TriageService.testProvider(providerValue() as Record<string, unknown>);
+            // The stored key comes back masked as '***'; omit it so the server falls back to
+            // the stored secret instead of testing against the literal placeholder.
+            const testPayload = { ...providerValue(), apiKey: resolveTestApiKey(apiKey) };
+            const res = await TriageService.testProvider(testPayload as Record<string, unknown>);
             setTestResult(res);
         } catch (e: any) {
             setTestResult({ ok: false, latencyMs: 0, error: e?.message || String(e) });

--- a/packages/syngrisi/src/ui-app/admin/components/Settings/Forms/Boolean.tsx
+++ b/packages/syngrisi/src/ui-app/admin/components/Settings/Forms/Boolean.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import { Checkbox, Button, Group, Title, Text } from '@mantine/core';
 import { useForm } from '@mantine/form';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { ISettingForm, ISettingFormUpdateData } from '@admin/components/Settings/Forms/interfaces';
 import SafeSelect from '@shared/components/SafeSelect';
 // actually this component not represent boolean data,
@@ -15,6 +15,14 @@ function Boolean({ name, value, label, description, enabled, updateSetting }: IS
             },
         },
     );
+
+    // Resync the form to fresh props (e.g. after save or a react-query
+    // refetch-on-window-focus), otherwise the shown value/enabled would
+    // stay frozen at the initial values forever.
+    useEffect(() => {
+        form.setValues({ value, enabled });
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [value, enabled]);
 
     const handleSubmit = (values: ISettingFormUpdateData) => {
         updateSetting.mutate(values);

--- a/packages/syngrisi/src/ui-app/admin/components/Settings/__tests__/resolveTestApiKey.test.ts
+++ b/packages/syngrisi/src/ui-app/admin/components/Settings/__tests__/resolveTestApiKey.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveTestApiKey, MASKED_API_KEY } from '../resolveTestApiKey';
+
+test('resolveTestApiKey returns undefined for the masked placeholder', () => {
+    assert.equal(resolveTestApiKey(MASKED_API_KEY), undefined);
+});
+
+test('resolveTestApiKey returns undefined for an empty string', () => {
+    assert.equal(resolveTestApiKey(''), undefined);
+});
+
+test('resolveTestApiKey returns undefined for undefined input', () => {
+    assert.equal(resolveTestApiKey(undefined), undefined);
+});
+
+test('resolveTestApiKey returns the real key unchanged', () => {
+    assert.equal(resolveTestApiKey('sk-real-key-123'), 'sk-real-key-123');
+});

--- a/packages/syngrisi/src/ui-app/admin/components/Settings/resolveTestApiKey.ts
+++ b/packages/syngrisi/src/ui-app/admin/components/Settings/resolveTestApiKey.ts
@@ -1,0 +1,8 @@
+// The stored API key is returned masked as '***'. When building the "Test connection"
+// payload, a masked key must be treated as "not provided" so the caller can omit it and
+// let the server fall back to the stored secret — sending '***' verbatim tests with a
+// bogus key. Returns undefined for a masked/empty key, otherwise the real value.
+export const MASKED_API_KEY = '***';
+export function resolveTestApiKey(apiKey: string | undefined): string | undefined {
+    return !apiKey || apiKey === MASKED_API_KEY ? undefined : apiKey;
+}

--- a/packages/syngrisi/src/ui-app/admin/components/Users/AdminUsers.tsx
+++ b/packages/syngrisi/src/ui-app/admin/components/Users/AdminUsers.tsx
@@ -49,7 +49,7 @@ export default function AdminUsers() {
             </ActionIcon>,
             50,
         );
-    }, []);
+    }, [colorScheme, refetch]);
 
     const [addUser, setAddUser] = useState(false);
 

--- a/packages/syngrisi/src/ui-app/admin/components/Users/UserForm.tsx
+++ b/packages/syngrisi/src/ui-app/admin/components/Users/UserForm.tsx
@@ -4,7 +4,7 @@ import { useForm } from '@mantine/form';
 import { ActionIcon, Group, TextInput } from '@mantine/core';
 import { IconEdit, IconSend, IconX } from '@tabler/icons-react';
 import { useMutation } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { errorMsg, log } from '@shared/utils';
 import { Password } from '@shared/components/Password';
 import ActionPopoverIcon from '@shared/components/ActionPopoverIcon';
@@ -47,12 +47,32 @@ export default function UserForm(
         },
     });
 
+    // Resync the form to fresh props (e.g. after "Reload users" or another admin's change).
+    // Guarded by !editMode so a refetch mid-edit never clobbers the user's unsaved input.
+    // editMode is in the deps so the row resyncs right after the user exits edit mode.
+    // Local-only fields (password) are intentionally left untouched.
+    useEffect(() => {
+        if (!editMode) {
+            form.setValues({
+                id,
+                username,
+                firstName,
+                lastName,
+                role,
+                updatedDate,
+                createdDate,
+            });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [id, username, firstName, lastName, role, updatedDate, createdDate, editMode]);
+
     const updateUser = useMutation(
         {
             mutationFn: (data: IUser) => GenericService.update('users', data),
             onSuccess: async (result: any) => {
                 successMsg({ message: `User: '${result.username}' has been successfully updated` });
                 log.debug({ result });
+                setEditMode(false);
                 refetch();
             },
             onError: (e: any) => {
@@ -79,7 +99,6 @@ export default function UserForm(
     const update = () => {
         if (form.validate().hasErrors) return;
         updateUser.mutate(form.values);
-        setEditMode(false);
     };
 
     const removeUser = () => {
@@ -107,7 +126,6 @@ export default function UserForm(
                         style={{ width: '11%' }}
                         data-test="user-list-first-name"
                         aria-label="First Name"
-                        value={firstName}
                         disabled={!editMode}
                         {...form.getInputProps('firstName')}
                     />
@@ -115,7 +133,6 @@ export default function UserForm(
                         style={{ width: '11%' }}
                         data-test="user-list-last-name"
                         aria-label="Last Name"
-                        value={lastName}
                         disabled={!editMode}
                         {...form.getInputProps('lastName')}
                     />


### PR DESCRIPTION
## Summary

Hardens the AI Triage / RCA subsystem (security + reliability) and fixes a batch of admin-panel bugs found in a follow-up audit. Ships a **patch** changeset (3.9.0 → 3.9.1).

### Security & reliability (server)
- **Auth + validation** on `PATCH /v1/app/:id/triage-policy` (was reachable unauthenticated with `z.any()`): now requires login + admin role and a strict Zod schema. Auth added to `GET /v1/app`.
- **XSS**: escape user/DB data in the `/ai/*` HTML views (reflected via query params, stored via check name).
- **Key isolation**: `OPENAI_API_KEY`/base-URL scoped to the openai provider only (no cross-provider leak).
- **SSRF info-leak**: "Test connection" no longer reflects raw upstream response bodies.
- **Triage reliability**: bulk restart is now async (via the scheduler); transient provider failures retry a bounded number of times instead of permanently burning a check, guarded so a check is only re-queued when the scheduler can actually drain it.

### Admin panel (UI)
- Confirm before DB restore and job delete; double-submit guards.
- "Test connection" stops sending the masked `***` key (server backfills the stored key).
- User row stays in edit mode until save succeeds; form resyncs on refetch.
- Settings/plugin forms resync with server state; numeric input no longer forced to `0`; debug logs removed.
- Confirm before discarding unsaved AI Triage edits on project switch; stable row keys; window-focus refetch disabled for the triage projects query.
- `rel="noopener"` on external link; log-refresh pluralization fix.

## Testing
- Unit: 66/67 (the one failure — `migrationRunner.test.ts` — is pre-existing, fails identically at the base commit, needs a live Mongo).
- E2E (Playwright BDD): full parallel suite **319 passed / 0 failed**, `@serial` 14/14, `@flaky` 22/22, AI_TRIAGE+RCA 56/56. SSO and `@live-vlm` excluded (need external infra). E2E ran green locally, so HEAD carries `[skip-e2e]`.

Note: an over-broad "single infinite-scroll trigger" refactor was reverted after E2E caught that it broke logs pagination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)