### PR TITLE
feat(comparison): true pixel-to-pixel mode as default (Pixel Perfect), keep ±16 as Tolerant

### DIFF
--- a/.changeset/pixel-perfect-default.md
+++ b/.changeset/pixel-perfect-default.md
@@ -1,0 +1,13 @@
+---
+"@syngrisi/syngrisi": minor
+"@syngrisi/node-resemble.js": minor
+---
+
+Add a true pixel-to-pixel comparison mode and make it the default
+
+The default comparison mode (`matchType: 'nothing'`, previously labelled **Standard**) now performs an **exact, zero-tolerance** pixel-to-pixel comparison and is labelled **Pixel Perfect** in the UI. The previous behaviour — which tolerated differences up to ±16 per colour channel despite being called "Standard" — is still available as a new **Tolerant** mode (`matchType: 'tolerant'`).
+
+- `node-resemble.js` gains an `exact()` method (all tolerances set to 0). `ignoreNothing()` keeps its ±16 behaviour and now backs the Tolerant mode.
+- Baseline match-type options: `nothing` (Pixel Perfect, exact, default), `tolerant` (allow minor per-pixel differences), `antialiasing`, `colors`.
+
+⚠️ **Behaviour change (no data migration):** existing baselines with `matchType: 'nothing'` (or unset) are now compared strictly. Renders that previously passed thanks to the ±16 tolerance may start reporting differences. To restore the old leniency for a baseline, switch its match type to **Tolerant**.

--- a/packages/node-resemble.js/README.md
+++ b/packages/node-resemble.js/README.md
@@ -59,7 +59,8 @@ var diff = resemble(file).compareTo(file2).ignoreColors().onComplete(function(da
 ##### You can also change the comparison method after the first analysis.
 
 ```javascript
-// diff.ignoreNothing();
+// diff.exact();          // true pixel-to-pixel, zero tolerance
+// diff.ignoreNothing();  // tolerant (±16 per channel)
 // diff.ignoreColors();
 diff.ignoreAntialiasing();
 ```

--- a/packages/node-resemble.js/resemble.js
+++ b/packages/node-resemble.js/resemble.js
@@ -532,6 +532,24 @@ _this['resemble'] = function (fileData) {
                 }
                 return self;
             },
+            exact: function () {
+
+                // True pixel-to-pixel comparison: any per-channel difference counts as a mismatch.
+                tolerance.red = 0;
+                tolerance.green = 0;
+                tolerance.blue = 0;
+                tolerance.alpha = 0;
+                tolerance.minBrightness = 0;
+                tolerance.maxBrightness = 255;
+
+                ignoreAntialiasing = false;
+                ignoreColors = false;
+
+                if (hasMethod) {
+                    param();
+                }
+                return self;
+            },
             ignoreAntialiasing: function () {
 
                 tolerance.red = 32;

--- a/packages/node-resemble.js/resemble.spec.js
+++ b/packages/node-resemble.js/resemble.spec.js
@@ -177,6 +177,16 @@ describe('node-resemble.js', function() {
 	  });
   });
 
+  it('exact() is at least as strict as ignoreNothing() (true pixel-to-pixel)', function(done) {
+    resemble(EXAMPLE_PEOPLE_IMAGES[0]).compareTo(EXAMPLE_PEOPLE_IMAGES[1]).exact().onComplete(function(exactData) {
+      resemble(EXAMPLE_PEOPLE_IMAGES[0]).compareTo(EXAMPLE_PEOPLE_IMAGES[1]).ignoreNothing().onComplete(function(tolerantData) {
+        // Zero tolerance must flag at least as many pixels as the ±16 "tolerant" mode.
+        expect(exactData.rawMisMatchPercentage).toBeGreaterThanOrEqual(tolerantData.rawMisMatchPercentage);
+        done();
+      });
+    });
+  });
+
   function getLargeImageComparison() {
     return resemble(EXAMPLE_LARGE_IMAGE).compareTo(EXAMPLE_LARGE_IMAGE);
   }

--- a/packages/syngrisi/e2e/features/DEMO/phase3_regions_demo.feature
+++ b/packages/syngrisi/e2e/features/DEMO/phase3_regions_demo.feature
@@ -64,7 +64,7 @@ Feature: Phase 3 Regions & Match Type Demo
 
         # ДЕМО ТОЧКА 5: Показываем Match Type Selector
         When I highlight element "[data-check='match-type-selector']"
-        And I announce: "Селектор режима сравнения - выбор между Standard, Ignore Anti-aliasing и Ignore Colors."
+        And I announce: "Селектор режима сравнения - выбор между Pixel Perfect, Tolerant, Ignore Anti-aliasing и Ignore Colors."
         And I pause for 1500 ms
         And I clear highlight
 
@@ -72,7 +72,7 @@ Feature: Phase 3 Regions & Match Type Demo
         Then the element with locator "[data-check='match-type-selector']" should be enabled
         When I click element with locator "[data-check='match-type-selector']"
         And I wait 0.5 seconds
-        And I announce: "Меню режимов: Standard - точное сравнение пикселей, Anti-aliasing - игнорирует различия сглаживания, Colors - сравнивает только структуру."
+        And I announce: "Меню режимов: Pixel Perfect - точное попиксельное сравнение, Tolerant - допускает мелкие различия, Anti-aliasing - игнорирует различия сглаживания, Colors - сравнивает только структуру."
         And I pause for 2000 ms
 
         # Закрываем меню кликом на тулбар (Escape закроет и модальное окно)

--- a/packages/syngrisi/src/server/lib/comparison/compareImagesNode.ts
+++ b/packages/syngrisi/src/server/lib/comparison/compareImagesNode.ts
@@ -28,9 +28,12 @@ export default function compareImages(image1: any, image2: any, options: any): P
             const ignoreTransform: any = {
                 antialiasing: 'ignoreAntialiasing',
                 colors: 'ignoreColors',
-                nothing: 'ignoreNothing',
+                // 'nothing' is the default and now means true pixel-to-pixel (zero tolerance).
+                nothing: 'exact',
+                // 'tolerant' keeps the previous "Standard" behaviour (±16 per channel).
+                tolerant: 'ignoreNothing',
             };
-            const ignoreMethod = ignoreTransform[options.ignore] ? ignoreTransform[options.ignore] : 'ignoreNothing';
+            const ignoreMethod = ignoreTransform[options.ignore] ? ignoreTransform[options.ignore] : 'exact';
 
             const outputOpts = options.output;
             resemble.outputSettings(outputOpts);

--- a/packages/syngrisi/src/server/models/Baseline.model.ts
+++ b/packages/syngrisi/src/server/models/Baseline.model.ts
@@ -20,7 +20,7 @@ export interface BaselineDocument extends Document {
     markedByUsername?: string;
     ignoreRegions?: string;
     boundRegions?: string;
-    matchType?: 'antialiasing' | 'nothing' | 'colors';
+    matchType?: 'antialiasing' | 'nothing' | 'colors' | 'tolerant';
     toleranceThreshold?: number;
     meta?: Record<string, unknown>;
 }
@@ -85,7 +85,7 @@ const BaselineSchema: Schema<BaselineDocument> = new Schema({
     },
     matchType: {
         type: String,
-        enum: ['antialiasing', 'nothing', 'colors'],
+        enum: ['antialiasing', 'nothing', 'colors', 'tolerant'],
     },
     toleranceThreshold: {
         type: Number,

--- a/packages/syngrisi/src/server/schemas/Baseline.schema.ts
+++ b/packages/syngrisi/src/server/schemas/Baseline.schema.ts
@@ -110,8 +110,8 @@ const BaselinePutSchema = z.object({
         description: 'JSON string representing the checked area (only compare within this region)',
         example: '[{"left":0,"top":0,"right":500,"bottom":300}]'
     }).optional(),
-    matchType: z.enum(['antialiasing', 'nothing', 'colors']).openapi({
-        description: 'Comparison mode: nothing (standard), antialiasing (auto-ignore), or colors (ignore color differences)',
+    matchType: z.enum(['antialiasing', 'nothing', 'colors', 'tolerant']).openapi({
+        description: 'Comparison mode: nothing (pixel-perfect, exact, default), tolerant (allow minor per-pixel differences, ±16), antialiasing (auto-ignore anti-aliasing), or colors (ignore color differences)',
         example: 'nothing'
     }).optional(),
     toleranceThreshold: z.number().min(0).max(100).openapi({

--- a/packages/syngrisi/src/server/services/check.service.ts
+++ b/packages/syngrisi/src/server/services/check.service.ts
@@ -52,7 +52,7 @@ export interface baselineParamsType extends Document {
     markedByUsername?: string;
     ignoreRegions?: string;
     boundRegions?: string;
-    matchType?: 'antialiasing' | 'nothing' | 'colors';
+    matchType?: 'antialiasing' | 'nothing' | 'colors' | 'tolerant';
     toleranceThreshold?: number;
     meta?: object;
     actualSnapshotId: Schema.Types.ObjectId;

--- a/packages/syngrisi/src/ui-app/index2/components/Tests/Table/Checks/CheckDetails/Toolbar/MatchTypeSelector.tsx
+++ b/packages/syngrisi/src/ui-app/index2/components/Tests/Table/Checks/CheckDetails/Toolbar/MatchTypeSelector.tsx
@@ -20,13 +20,18 @@ interface Props {
     checkQuery?: any;
 }
 
-type MatchType = 'nothing' | 'antialiasing' | 'colors';
+type MatchType = 'nothing' | 'antialiasing' | 'colors' | 'tolerant';
 
 const MATCH_TYPE_OPTIONS: { value: MatchType; label: string; description: string }[] = [
     {
         value: 'nothing',
-        label: 'Standard',
-        description: 'Compare all pixels exactly',
+        label: 'Pixel Perfect',
+        description: 'Compare every pixel exactly (no tolerance)',
+    },
+    {
+        value: 'tolerant',
+        label: 'Tolerant',
+        description: 'Allow minor per-pixel differences (±16)',
     },
     {
         value: 'antialiasing',


### PR DESCRIPTION
## Summary
- Adds a **true pixel-to-pixel** comparison mode (zero tolerance) and makes it the default.
- The default `matchType: 'nothing'` (was **Standard**) is now labelled **Pixel Perfect** and compares exactly.
- The previous ±16-per-channel behaviour is preserved as a new **Tolerant** mode (`matchType: 'tolerant'`).

## Changes
- `node-resemble.js`: new `exact()` method (all tolerances 0); `ignoreNothing()` keeps ±16 and now backs Tolerant.
- `compareImagesNode.ts`: map `nothing → exact` (default fallback exact), `tolerant → ignoreNothing`.
- Baseline model/schema enums + `check.service` type gain `tolerant`.
- UI `MatchTypeSelector`: Pixel Perfect (default) + Tolerant options.
- resemble spec asserts `exact()` is at least as strict as `ignoreNothing()`.

## ⚠️ Behaviour change (no migration)
Existing baselines with `matchType: 'nothing'`/unset are now compared strictly — near-matches that passed under ±16 may start reporting diffs. Switch a baseline to **Tolerant** to restore the old leniency.

## Testing
- resemble jasmine: 16/16 (incl. new exact test)
- server typecheck + UI (Vite) build: clean
- e2e `CHECKS_HANDLING/` (incl. tolerance, ident, low_diff, 1px, standard_flow): **30/30 green** → no false-positive regressions in the fixture-based suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)