### PR TITLE
feat(comparison): true pixel-to-pixel as default (Pixel Perfect), keep ±16 as Tolerant

### DIFF
--- a/.changeset/pixel-perfect-default.md
+++ b/.changeset/pixel-perfect-default.md
@@ -1,0 +1,13 @@
+---
+"@syngrisi/syngrisi": minor
+"@syngrisi/node-resemble.js": minor
+---
+
+Add a true pixel-to-pixel comparison mode and make it the default
+
+The default comparison mode (`matchType: 'nothing'`, previously labelled **Standard**) now performs an **exact, zero-tolerance** pixel-to-pixel comparison and is labelled **Pixel Perfect** in the UI. The previous behaviour — which tolerated differences up to ±16 per colour channel despite being called "Standard" — is still available as a new **Tolerant** mode (`matchType: 'tolerant'`).
+
+- `node-resemble.js` gains an `exact()` method (all tolerances set to 0). `ignoreNothing()` keeps its ±16 behaviour and now backs the Tolerant mode.
+- Baseline match-type options: `nothing` (Pixel Perfect, exact, default), `tolerant` (allow minor per-pixel differences), `antialiasing`, `colors`.
+
+⚠️ **Behaviour change (no data migration):** existing baselines with `matchType: 'nothing'` (or unset) are now compared strictly. Renders that previously passed thanks to the ±16 tolerance may start reporting differences. To restore the old leniency for a baseline, switch its match type to **Tolerant**.

--- a/.changeset/pixel-perfect-default.md
+++ b/.changeset/pixel-perfect-default.md
@@ -10,4 +10,4 @@ The default comparison mode (`matchType: 'nothing'`, previously labelled **Stand
 - `node-resemble.js` gains an `exact()` method (all tolerances set to 0). `ignoreNothing()` keeps its ±16 behaviour and now backs the Tolerant mode.
 - Baseline match-type options: `nothing` (Pixel Perfect, exact, default), `tolerant` (allow minor per-pixel differences), `antialiasing`, `colors`.
 
-⚠️ **Behaviour change (no data migration):** existing baselines with `matchType: 'nothing'` (or unset) are now compared strictly. Renders that previously passed thanks to the ±16 tolerance may start reporting differences. To restore the old leniency for a baseline, switch its match type to **Tolerant**.
+⚠️ **Behaviour change (no data migration):** existing baselines with `matchType: 'nothing'` (or unset) are now compared strictly. Renders that previously passed thanks to the ±16 tolerance may start reporting differences, and reported diff percentages go up (so more checks exceed the 5% ceiling under which the diff-highlight tool is offered). To restore the old leniency for a baseline, switch its match type to **Tolerant**.

--- a/packages/node-resemble.js/README.md
+++ b/packages/node-resemble.js/README.md
@@ -59,7 +59,8 @@ var diff = resemble(file).compareTo(file2).ignoreColors().onComplete(function(da
 ##### You can also change the comparison method after the first analysis.
 
 ```javascript
-// diff.ignoreNothing();
+// diff.exact();          // true pixel-to-pixel, zero tolerance
+// diff.ignoreNothing();  // tolerant (±16 per channel)
 // diff.ignoreColors();
 diff.ignoreAntialiasing();
 ```

--- a/packages/node-resemble.js/resemble.js
+++ b/packages/node-resemble.js/resemble.js
@@ -532,6 +532,24 @@ _this['resemble'] = function (fileData) {
                 }
                 return self;
             },
+            exact: function () {
+
+                // True pixel-to-pixel comparison: any per-channel difference counts as a mismatch.
+                tolerance.red = 0;
+                tolerance.green = 0;
+                tolerance.blue = 0;
+                tolerance.alpha = 0;
+                tolerance.minBrightness = 0;
+                tolerance.maxBrightness = 255;
+
+                ignoreAntialiasing = false;
+                ignoreColors = false;
+
+                if (hasMethod) {
+                    param();
+                }
+                return self;
+            },
             ignoreAntialiasing: function () {
 
                 tolerance.red = 32;

--- a/packages/node-resemble.js/resemble.spec.js
+++ b/packages/node-resemble.js/resemble.spec.js
@@ -177,6 +177,16 @@ describe('node-resemble.js', function() {
 	  });
   });
 
+  it('exact() is at least as strict as ignoreNothing() (true pixel-to-pixel)', function(done) {
+    resemble(EXAMPLE_PEOPLE_IMAGES[0]).compareTo(EXAMPLE_PEOPLE_IMAGES[1]).exact().onComplete(function(exactData) {
+      resemble(EXAMPLE_PEOPLE_IMAGES[0]).compareTo(EXAMPLE_PEOPLE_IMAGES[1]).ignoreNothing().onComplete(function(tolerantData) {
+        // Zero tolerance must flag at least as many pixels as the ±16 "tolerant" mode.
+        expect(exactData.rawMisMatchPercentage).toBeGreaterThanOrEqual(tolerantData.rawMisMatchPercentage);
+        done();
+      });
+    });
+  });
+
   function getLargeImageComparison() {
     return resemble(EXAMPLE_LARGE_IMAGE).compareTo(EXAMPLE_LARGE_IMAGE);
   }

--- a/packages/syngrisi/e2e/features/CP/check_details/appearance_common.feature
+++ b/packages/syngrisi/e2e/features/CP/check_details/appearance_common.feature
@@ -147,8 +147,8 @@ Feature: Check Detail Appearance
     When I wait 10 seconds for the element with locator "[data-check='toolbar'] [data-test='check-accept-icon'][data-popover-icon-name='CheckName'] svg" to be visible
     Then the element with locator "[data-check='toolbar'] [data-test='check-accept-icon'][data-popover-icon-name='CheckName'] svg" should have has attribute "data-test-icon-type=outline"
     Then the css attribute "color" from element "[data-check='toolbar'] [data-test='check-accept-icon'][data-popover-icon-name='CheckName'] svg" is "rgba(64,192,87,1)"
-    # diff percent
-    Then the element with locator "[data-check='diff-percent']" should have contains text "1.34%"
+    # diff percent (exact/Pixel Perfect default: every differing pixel counts)
+    Then the element with locator "[data-check='diff-percent']" should have contains text "5.73%"
 
     # default view
     Then the element with locator "[data-segment-value='diff']" should have attribute "data-segment-active" "true"
@@ -160,7 +160,9 @@ Feature: Check Detail Appearance
     Then the element with locator "[data-segment-value='slider']" should have attribute "data-segment-disabled" "false"
 
     # action icons (FAILED check - has baseline, add enabled, but no regions so save is disabled)
-    Then  the element "[data-check='highlight-icon']" does not have attribute "data-disabled" "true"
+    # highlight-icon is disabled here: diff highlighting is only offered when the
+    # difference is < 5%, and the exact default puts A.png vs B.png at 5.73%.
+    Then  the element "[data-check='highlight-icon']" has attribute "data-disabled" "true"
     Then  the element "[data-check='remove-ignore-region']" has attribute "data-disabled" "true"
     Then  the element "[data-check='add-ignore-region']" does not have attribute "data-disabled" "true"
     Then  the element "[data-check='save-ignore-region']" has attribute "data-disabled" "true"

--- a/packages/syngrisi/e2e/features/CP/check_details/heighlight.feature
+++ b/packages/syngrisi/e2e/features/CP/check_details/heighlight.feature
@@ -15,6 +15,10 @@ Feature: Check Details Difference Highlight
               filePath: files/A.png
       """
     When I accept via http the 1st check with name "CheckName"
+    # Difference highlighting is only available when the diff is < 5%.
+    # Use the "tolerant" (±16) mode so A.png vs B.png stays at ~1.34% instead of
+    # the exact-mode 5.73%, keeping the highlight feature under test.
+    When I set via http baseline "CheckName" matchType to "tolerant"
     Given I create "1" tests with:
       """
           testName: "TestName"

--- a/packages/syngrisi/e2e/features/DEMO/phase3_regions_demo.feature
+++ b/packages/syngrisi/e2e/features/DEMO/phase3_regions_demo.feature
@@ -64,7 +64,7 @@ Feature: Phase 3 Regions & Match Type Demo
 
         # ДЕМО ТОЧКА 5: Показываем Match Type Selector
         When I highlight element "[data-check='match-type-selector']"
-        And I announce: "Селектор режима сравнения - выбор между Standard, Ignore Anti-aliasing и Ignore Colors."
+        And I announce: "Селектор режима сравнения - выбор между Pixel Perfect, Tolerant, Ignore Anti-aliasing и Ignore Colors."
         And I pause for 1500 ms
         And I clear highlight
 
@@ -72,7 +72,7 @@ Feature: Phase 3 Regions & Match Type Demo
         Then the element with locator "[data-check='match-type-selector']" should be enabled
         When I click element with locator "[data-check='match-type-selector']"
         And I wait 0.5 seconds
-        And I announce: "Меню режимов: Standard - точное сравнение пикселей, Anti-aliasing - игнорирует различия сглаживания, Colors - сравнивает только структуру."
+        And I announce: "Меню режимов: Pixel Perfect - точное попиксельное сравнение, Tolerant - допускает мелкие различия, Anti-aliasing - игнорирует различия сглаживания, Colors - сравнивает только структуру."
         And I pause for 2000 ms
 
         # Закрываем меню кликом на тулбар (Escape закроет и модальное окно)

--- a/packages/syngrisi/e2e/features/PLUGINS/check_threshold.feature
+++ b/packages/syngrisi/e2e/features/PLUGINS/check_threshold.feature
@@ -49,7 +49,7 @@ Feature: Plugin System - Check Mismatch Threshold
           testName: PluginThresholdAboveTest
           checks:
             - checkName: AboveThresholdCheck
-              filePath: files/a.png
+              filePath: files/A.png
       """
     When I accept via http the 1st check with name "AboveThresholdCheck"
 
@@ -59,7 +59,7 @@ Feature: Plugin System - Check Mismatch Threshold
           testName: PluginThresholdAboveTest
           checks:
             - checkName: AboveThresholdCheck
-              filePath: files/b.png
+              filePath: files/B.png
       """
 
     # Verify: check status should be failed (above threshold)

--- a/packages/syngrisi/e2e/features/PLUGINS/plugin_init.feature
+++ b/packages/syngrisi/e2e/features/PLUGINS/plugin_init.feature
@@ -15,7 +15,7 @@ Feature: Plugin System Initialization
           testName: NoPluginTest
           checks:
             - checkName: TestCheck
-              filePath: files/a.png
+              filePath: files/A.png
       """
     Then I expect via http 1st check filtered as "name=TestCheck" matched:
       """
@@ -35,7 +35,7 @@ Feature: Plugin System Initialization
           testName: WithPluginTest
           checks:
             - checkName: PluginCheck
-              filePath: files/a.png
+              filePath: files/A.png
       """
     Then I expect via http 1st check filtered as "name=PluginCheck" matched:
       """

--- a/packages/syngrisi/e2e/steps/domain/http/baselines-backend.steps.ts
+++ b/packages/syngrisi/e2e/steps/domain/http/baselines-backend.steps.ts
@@ -1024,3 +1024,38 @@ When(
     expect(updated.toleranceThreshold).toBe(tolerance);
   }
 );
+
+When(
+  'I set via http baseline {string} matchType to {string}',
+  async (
+    { appServer, testData }: { appServer: AppServerFixture; testData: TestStore },
+    baselineName: string,
+    matchType: string
+  ) => {
+    const filter = encodeURIComponent(JSON.stringify({ name: baselineName }));
+    const uri = `${appServer.baseURL}/v1/baselines?limit=1&filter=${filter}`;
+    logger.info(`Looking up baseline "${baselineName}"`);
+    const response = await requestWithSession(uri, testData, appServer);
+    const baselines = response.json.results;
+    expect(baselines.length).toBeGreaterThan(0);
+    const baselineId = baselines[0]._id;
+
+    const putUri = `${appServer.baseURL}/v1/baselines/${baselineId}`;
+    logger.info(`Setting matchType "${matchType}" on baseline ${baselineId}`);
+    const headers = createAuthHeaders(testData, appServer);
+    await got.put(putUri, {
+      json: { matchType },
+      headers,
+    }).json<any>();
+
+    // Verify via GET
+    const verifyResponse = await requestWithSession(
+      `${appServer.baseURL}/v1/baselines?limit=1&filter=${filter}`,
+      testData,
+      appServer
+    );
+    const updated = verifyResponse.json.results[0];
+    logger.info(`Baseline matchType verified: ${updated.matchType}`);
+    expect(updated.matchType).toBe(matchType);
+  }
+);

--- a/packages/syngrisi/src/server/lib/comparison/compareImagesNode.ts
+++ b/packages/syngrisi/src/server/lib/comparison/compareImagesNode.ts
@@ -28,9 +28,12 @@ export default function compareImages(image1: any, image2: any, options: any): P
             const ignoreTransform: any = {
                 antialiasing: 'ignoreAntialiasing',
                 colors: 'ignoreColors',
-                nothing: 'ignoreNothing',
+                // 'nothing' is the default and now means true pixel-to-pixel (zero tolerance).
+                nothing: 'exact',
+                // 'tolerant' keeps the previous "Standard" behaviour (±16 per channel).
+                tolerant: 'ignoreNothing',
             };
-            const ignoreMethod = ignoreTransform[options.ignore] ? ignoreTransform[options.ignore] : 'ignoreNothing';
+            const ignoreMethod = ignoreTransform[options.ignore] ? ignoreTransform[options.ignore] : 'exact';
 
             const outputOpts = options.output;
             resemble.outputSettings(outputOpts);

--- a/packages/syngrisi/src/server/models/Baseline.model.ts
+++ b/packages/syngrisi/src/server/models/Baseline.model.ts
@@ -20,7 +20,7 @@ export interface BaselineDocument extends Document {
     markedByUsername?: string;
     ignoreRegions?: string;
     boundRegions?: string;
-    matchType?: 'antialiasing' | 'nothing' | 'colors';
+    matchType?: 'antialiasing' | 'nothing' | 'colors' | 'tolerant';
     toleranceThreshold?: number;
     meta?: Record<string, unknown>;
 }
@@ -85,7 +85,7 @@ const BaselineSchema: Schema<BaselineDocument> = new Schema({
     },
     matchType: {
         type: String,
-        enum: ['antialiasing', 'nothing', 'colors'],
+        enum: ['antialiasing', 'nothing', 'colors', 'tolerant'],
     },
     toleranceThreshold: {
         type: Number,

--- a/packages/syngrisi/src/server/schemas/Baseline.schema.ts
+++ b/packages/syngrisi/src/server/schemas/Baseline.schema.ts
@@ -110,8 +110,8 @@ const BaselinePutSchema = z.object({
         description: 'JSON string representing the checked area (only compare within this region)',
         example: '[{"left":0,"top":0,"right":500,"bottom":300}]'
     }).optional(),
-    matchType: z.enum(['antialiasing', 'nothing', 'colors']).openapi({
-        description: 'Comparison mode: nothing (standard), antialiasing (auto-ignore), or colors (ignore color differences)',
+    matchType: z.enum(['antialiasing', 'nothing', 'colors', 'tolerant']).openapi({
+        description: 'Comparison mode: nothing (pixel-perfect, exact, default), tolerant (allow minor per-pixel differences, ±16), antialiasing (auto-ignore anti-aliasing), or colors (ignore color differences)',
         example: 'nothing'
     }).optional(),
     toleranceThreshold: z.number().min(0).max(100).openapi({

--- a/packages/syngrisi/src/server/services/check.service.ts
+++ b/packages/syngrisi/src/server/services/check.service.ts
@@ -52,7 +52,7 @@ export interface baselineParamsType extends Document {
     markedByUsername?: string;
     ignoreRegions?: string;
     boundRegions?: string;
-    matchType?: 'antialiasing' | 'nothing' | 'colors';
+    matchType?: 'antialiasing' | 'nothing' | 'colors' | 'tolerant';
     toleranceThreshold?: number;
     meta?: object;
     actualSnapshotId: Schema.Types.ObjectId;

--- a/packages/syngrisi/src/ui-app/index2/components/Tests/Table/Checks/CheckDetails/Toolbar/MatchTypeSelector.tsx
+++ b/packages/syngrisi/src/ui-app/index2/components/Tests/Table/Checks/CheckDetails/Toolbar/MatchTypeSelector.tsx
@@ -20,13 +20,18 @@ interface Props {
     checkQuery?: any;
 }
 
-type MatchType = 'nothing' | 'antialiasing' | 'colors';
+type MatchType = 'nothing' | 'antialiasing' | 'colors' | 'tolerant';
 
 const MATCH_TYPE_OPTIONS: { value: MatchType; label: string; description: string }[] = [
     {
         value: 'nothing',
-        label: 'Standard',
-        description: 'Compare all pixels exactly',
+        label: 'Pixel Perfect',
+        description: 'Compare every pixel exactly (no tolerance)',
+    },
+    {
+        value: 'tolerant',
+        label: 'Tolerant',
+        description: 'Allow minor per-pixel differences (±16)',
     },
     {
         value: 'antialiasing',


### PR DESCRIPTION
Re-land of #47 (which was reverted) plus the test/fixture fixes that the full E2E run surfaced.

## Feature
- New resemble `exact()` method (zero tolerance). Default `matchType: 'nothing'` is now true pixel-to-pixel, relabelled **Pixel Perfect**.
- Old ±16 behaviour preserved as a new **Tolerant** mode.

## Why #47 was reverted, and what changed here
Exact-by-default raises diff percentages on existing checks (fixture A.png vs B.png: **1.34% → 5.73%**), which crosses the **5% ceiling that gates the diff-highlight tool**. That broke two check-detail e2e tests. Fixed by:
- `appearance_common`: assert the new exact reality (5.73%, highlight disabled for the >5% FAILED check).
- `heighlight`: set the baseline to `tolerant` so the diff stays <5% and the highlight feature (151 objects) is still exercised; added an `I set via http baseline <name> matchType to <mode>` step.

## Also fixed (pre-existing, unrelated)
`PLUGINS/{plugin_init,check_threshold}.feature` referenced lowercase `a.png`/`b.png` that only resolve on case-insensitive filesystems; now use `A.png`/`B.png`. This was masked because releases push with `[skip-e2e]`.

## ⚠️ Behaviour change (no migration)
Existing `nothing`/unset baselines now compare strictly; diff % go up; diff-highlight is offered for fewer checks. Switch a baseline to **Tolerant** to restore ±16 leniency.

## Testing
- resemble jasmine 16/16; server typecheck + UI build clean.
- Locally green: heighlight, appearance_common, check_threshold, plugin_init (6/6), plus the full CHECKS_HANDLING suite earlier (30/30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)