### PR TITLE
ci: make E2E opt-in on CI (off by default); mandate local E2E in rules

### DIFF
--- a/.changeset/e2e-ci-opt-in.md
+++ b/.changeset/e2e-ci-opt-in.md
@@ -1,0 +1,5 @@
+---
+"@syngrisi/syngrisi": patch
+---
+
+CI no longer runs E2E tests by default. E2E on CI is now opt-in and runs only when the pushed HEAD commit message contains the `[run-e2e]` marker (or via the manual "E2E Tests" workflow). Running E2E locally before merging/releasing is required instead. Documentation updated accordingly.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,10 @@ jobs:
   test-e2e:
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip-e2e]') && !startsWith(github.event.head_commit.message, 'chore(release):')
+    # E2E on CI is OFF by default and opt-in only: it runs solely when the pushed
+    # HEAD commit message contains the [run-e2e] marker (add it only at the user's
+    # request). E2E must be run locally before merging/releasing instead.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, '[run-e2e]')
     services:
       mongodb:
         image: mongo:8.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,10 @@
 
 If a user asks to run "syngrisi tests" or "e2e tests", treat that as running `yarn test` from `packages/syngrisi`.
 
-If the relevant E2E suite already passed locally, add `[skip-e2e]` to the HEAD commit message when pushing so CI does not re-run E2E (build, unit tests and the release workflow still run). Never use `[skip ci]` — it blocks the release workflow. See [Release Cycle Documentation](docs-src/RELEASE_CYCLE.md).
+### E2E policy
+
+-   **Local E2E is mandatory.** Before merging or releasing changes that can affect runtime behaviour, run the relevant E2E suite locally and confirm it is green. The only exception is when the user explicitly asks to skip E2E.
+-   **CI E2E is opt-in and off by default.** E2E does NOT run on CI unless the user explicitly asks for it. To make CI run E2E, add the `[run-e2e]` marker to the HEAD commit message when pushing; without it, CI runs only build, unit tests and the release workflow. Never use `[skip ci]` — it blocks the release workflow. See [Release Cycle Documentation](docs-src/RELEASE_CYCLE.md).
 
 ## Design & Coding Principles
 

--- a/docs-src/RELEASE_CYCLE.md
+++ b/docs-src/RELEASE_CYCLE.md
@@ -17,9 +17,9 @@ This monorepo uses **Changesets** for version management and automated releases 
    Brief description of changes
    ```
 
-2. **Commit and push** the changeset (add `[skip-e2e]` if E2E tests already passed locally):
+2. **Run E2E locally first** (mandatory unless the user explicitly asked to skip it), then **commit and push** the changeset:
    ```bash
-   git add .changeset/ && git commit -m "chore: add changeset [skip-e2e]" && git push
+   git add .changeset/ && git commit -m "chore: add changeset" && git push
    ```
 
 3. **Wait for CI** (build + unit tests) → Release workflow automatically creates a PR titled "chore(release): version packages"
@@ -28,10 +28,6 @@ This monorepo uses **Changesets** for version management and automated releases 
    ```bash
    git fetch origin changeset-release/main && git merge origin/changeset-release/main && git push
    ```
-   > If the merge commit triggers E2E and they fail on flaky tests, push a retry:
-   > ```bash
-   > git commit --allow-empty -m "ci: retry [skip-e2e]" && git push
-   > ```
 
 5. **Wait for Release workflow** — it publishes packages to npm and creates a GitHub Release
 
@@ -41,27 +37,33 @@ This monorepo uses **Changesets** for version management and automated releases 
    gh release list --limit 3
    ```
 
-## Skip E2E Tests on CI
+## E2E Tests on CI (opt-in, off by default)
 
-Add `[skip-e2e]` to the commit message to skip E2E tests while keeping build, unit tests, and release workflow running:
+**Running E2E locally is mandatory** before merging or releasing. The only
+exception is when the user explicitly asks to skip it.
+
+CI does **not** run E2E by default. To make CI run E2E, add the `[run-e2e]`
+marker to the pushed HEAD commit message — and do so **only when the user
+explicitly asks** for E2E on CI:
 
 ```bash
-git commit -m "chore: add changeset [skip-e2e]"
-# or for an empty retry commit:
-git commit --allow-empty -m "ci: retry [skip-e2e]"
+git commit -m "chore: some change [run-e2e]"
+# or trigger the manual "E2E Tests" workflow from the Actions tab (workflow_dispatch)
 ```
 
-> **Warning**: Do NOT use `[skip ci]` in commit messages — this blocks ALL workflows including the release workflow! Use `[skip-e2e]` instead.
+Without `[run-e2e]`, CI runs only build, unit tests and the release workflow.
 
-## Quick Release (Skip CI Tests)
+> **Warning**: Do NOT use `[skip ci]` in commit messages — this blocks ALL workflows including the release workflow!
 
-If tests have already been run locally and you want to release quickly:
+## Quick Release
 
-### Option A: Skip E2E via commit message (no admin rights needed)
+Since CI does not run E2E by default, a normal push already runs only build + unit tests before the release workflow. Just create the changeset and push:
 
-1. Create changeset and commit with `[skip-e2e]`:
+### Option A: Standard release (no admin rights needed)
+
+1. Create changeset and commit (no marker needed — CI skips E2E by default):
    ```bash
-   git commit -m "chore: add changeset [skip-e2e]" && git push
+   git commit -m "chore: add changeset" && git push
    ```
 2. Wait for CI (build + unit tests only) → Release workflow creates a PR
 3. Merge the PR → Release workflow publishes to npm

--- a/packages/syngrisi/CLAUDE.md
+++ b/packages/syngrisi/CLAUDE.md
@@ -127,10 +127,9 @@ See root `AGENTS.md` for full release documentation. Quick reference:
 npx changeset add
 # Select @syngrisi/syngrisi, choose version type (patch/minor/major), add description
 
-# 2. Commit and push.
-#    If the relevant E2E tests already passed locally, add [skip-e2e] to the
-#    HEAD commit message so CI does not re-run E2E (see "Skip E2E on CI" below).
-git add .changeset/ && git commit -m "chore: add changeset [skip-e2e]" && git push
+# 2. Commit and push. Run the relevant E2E suite LOCALLY first (mandatory unless
+#    the user asked to skip it). CI does not run E2E by default (see "E2E on CI" below).
+git add .changeset/ && git commit -m "chore: add changeset" && git push
 
 # 3. Wait for "chore(release): version packages" PR from GitHub Actions
 # 4. Merge PR → automatic npm publish + GitHub Release
@@ -141,13 +140,16 @@ Version types:
 - **minor**: New features (backwards compatible)
 - **major**: Breaking changes
 
-### Skip E2E on CI when it already passed locally
+### E2E on CI (opt-in, off by default)
 
-CI keys off the **HEAD commit message** (`ci.yml`: `!contains(head_commit.message, '[skip-e2e]')`).
-If you have already run the relevant E2E suite locally and it is green, add
-`[skip-e2e]` to the commit you push so CI skips E2E while still running build,
-unit tests and the release workflow. Do **not** use `[skip ci]` — that blocks
-the release workflow too. See `docs-src/RELEASE_CYCLE.md`.
+Running E2E **locally is mandatory** before merging or releasing — the only
+exception is when the user explicitly asks to skip it.
+
+CI does **not** run E2E by default. It keys off the **HEAD commit message**
+(`ci.yml`: `contains(head_commit.message, '[run-e2e]')`). Add `[run-e2e]` to the
+pushed commit **only when the user explicitly asks** for E2E on CI; otherwise CI
+runs just build, unit tests and the release workflow. Do **not** use `[skip ci]`
+— that blocks the release workflow too. See `docs-src/RELEASE_CYCLE.md`.
 
 ## Data Model
 

--- a/packages/syngrisi/e2e/CLAUDE.md
+++ b/packages/syngrisi/e2e/CLAUDE.md
@@ -2,6 +2,11 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## E2E run policy
+
+- **Local E2E is mandatory** before merging or releasing any change that can affect runtime behaviour. Run the relevant suite locally and confirm it is green. The only exception is when the user explicitly asks to skip E2E.
+- **CI E2E is opt-in and off by default.** It runs only when the user explicitly asks for it, via the `[run-e2e]` marker in the pushed HEAD commit message (or the manual "E2E Tests" workflow_dispatch). Do not add `[run-e2e]` on your own initiative.
+
 ## Build & Test Commands
 
 ```bash


### PR DESCRIPTION
## What
- **CI E2E is now opt-in and off by default.** `ci.yml` runs the `test-e2e` job only when the pushed HEAD commit message contains `[run-e2e]` (previously it ran by default unless `[skip-e2e]`).
- **Rules updated** (`CLAUDE.md`, `packages/syngrisi/CLAUDE.md`, `packages/syngrisi/e2e/CLAUDE.md`, `docs-src/RELEASE_CYCLE.md`): running E2E **locally is mandatory** before merge/release (exception: user explicitly asks to skip); CI E2E runs **only at the user's request** via the `[run-e2e]` marker or the manual "E2E Tests" workflow.

## Why
E2E on CI is slow and prone to runner-side flakiness (OOM/SIGKILL). Making it explicit opt-in keeps `main` CI fast and deterministic, while local E2E remains the required gate.

No runtime/package code touched. `ci.yml` YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)