### PR TITLE
feat(skill): demo-seed — isolated demo instance + feature-grouped seeder

### DIFF
--- a/.claude/skills/demo-seed/SKILL.md
+++ b/.claude/skills/demo-seed/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: demo-seed
+description: Spin up an isolated, fully-featured Syngrisi demo instance and seed it with a feature tour built from REAL test-app fixtures. Use when the user wants a runnable demo/sandbox to look at the UI, show off features (visual diffs, match types, ignore regions, AI Triage & auto-accept, RCA DOM diff, cross-browser, branches), or reproduce a flow with realistic data. Features are grouped by run name so the runs list reads as a tour.
+invocation: /demo-seed
+version: 1.0.0
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Syngrisi Demo Instance + Seeder
+
+Boots an isolated Syngrisi server (separate DB + images dir, auth off, every
+feature flag on) and seeds it with data that exercises the whole product,
+grouped one-feature-per-run. All examples reuse REAL fixtures from the test app
+(`packages/syngrisi/tests/files/*.png` and the RCA DOM pages under
+`packages/syngrisi/e2e/fixtures/rca-test-scenarios`).
+
+## Run it
+
+```bash
+# build (server + UI + playwright-sdk) if needed, start the server, seed it
+seed-data/run-demo.sh
+
+# faster: skip the build if dist is already current
+SKIP_BUILD=1 seed-data/run-demo.sh
+
+# custom port / db / images dir
+PORT=3010 DB=SyngrisiDemo IMAGES=/tmp/demo-imgs seed-data/run-demo.sh
+
+# stop the running demo server
+seed-data/run-demo.sh stop
+```
+
+When it finishes it prints the URL (default **http://localhost:3000**), the
+server PID (log at `seed-data/.demo-server.log`), and the stop command.
+
+Requirements: a local MongoDB running on `127.0.0.1:27017`.
+
+## What the script does
+
+1. Builds `packages/syngrisi` (server + UI) and `packages/playwright-sdk` (skip with `SKIP_BUILD=1`).
+2. Drops the demo DB + images dir **before** starting, so the run is clean and the server re-seeds default settings on boot (`createInitialSettings()`).
+3. Starts an isolated server with every feature on:
+   `SYNGRISI_AUTH=false SYNGRISI_TEST_MODE=true SYNGRISI_RCA=true SYNGRISI_DISABLE_DOM_DATA=false SYNGRISI_AI_TRIAGE_ENABLED=true SYNGRISI_AI_TRIAGE_POLL_INTERVAL_MS=2000`, isolated `SYNGRISI_DB_URI` + `SYNGRISI_IMAGES_PATH`.
+4. Symlinks the local (current) `@syngrisi/playwright-sdk` into `seed-data` — the npm copy is older and lacks DOM/RCA support.
+5. Runs the feature-grouped seeder (`seed-data/tests/demo-seed.spec.ts`, `yarn seed:demo`).
+
+## Feature tour (one run per feature)
+
+| Run | Feature | Fixtures |
+|-----|---------|----------|
+| **Passing** | green checks | A.png vs A.png |
+| **Regression** | failed visual diff | A.png vs B.png (~5.7%) |
+| **New Baselines** | `new` status | People1/People2.png, never accepted |
+| **Match · Tolerant** | `matchType: tolerant` + threshold | low_diff_0 vs low_diff_1 |
+| **Match · Anti-aliasing** | `matchType: antialiasing` | anti_off vs anti_on |
+| **Ignore Regions** | masked comparison region | A vs B with an ignore box |
+| **AI Triage** | deterministic AI verdicts (fake provider → `/ai/triage/:id/run`) | likely_bug@9, noise@8, intended_change@8, noise@3 (masked to unknown) |
+| **AI Auto-Accept** | triage auto-accept policy | noise@10 → auto-accepted; likely_bug@10 → kept for review |
+| **RCA** | root-cause DOM diff | base.html vs added-elements/text-change/broken-layout, DOM captured live |
+| **Cross-browser** | browser/viewport/OS variety | chromium/firefox/webkit |
+| **Branches** | per-branch runs | main/develop/feature/release |
+
+## How AI verdicts stay deterministic
+
+The seeder sets the **fake** triage provider (`PATCH /v1/settings/ai_triage_provider`)
+with the exact `fakeVerdict`/`fakeConfidence` it wants, then triages each check
+synchronously via `POST /ai/triage/:id/run`. It deliberately does **not** enable
+the app for the background scheduler, so no scheduler run races the verdict.
+Auto-accept is driven by the app's `triagePolicy` (applied inside the manual run),
+so it works without the scheduler too.
+
+## Editing / extending
+
+- Seeder logic: `seed-data/tests/demo-seed.spec.ts` — each `test()` is one feature/run and is independent (`--workers=1`, no serial-abort).
+- Helpers: `makeBaseline()` (creates + accepts a baseline, returns the VRSBaseline id), `makeActual()` (submits the compared check), plus raw HTTP helpers for triage/settings/baseline PUTs (auth is off, so no auth header is needed).
+- To add a run, copy an existing `test()` and give it a distinct `run` name.

--- a/packages/syngrisi/.gitignore
+++ b/packages/syngrisi/.gitignore
@@ -30,3 +30,4 @@ logs/**
 /static/data/custom_devices.json
 mvc/**
 .zencoder/
+.demo-images/

--- a/seed-data/.gitignore
+++ b/seed-data/.gitignore
@@ -3,3 +3,5 @@ test-results/
 playwright-report/
 *.log
 .DS_Store
+.demo-server.log
+.demo-server.pid

--- a/seed-data/package.json
+++ b/seed-data/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "description": "Seed data generator for Syngrisi server to showcase different check statuses",
   "scripts": {
-    "seed": "npx playwright test",
-    "seed:fast": "SEED_MODE=fast npx playwright test"
+    "seed": "npx playwright test seed.spec.ts",
+    "seed:fast": "SEED_MODE=fast npx playwright test seed.spec.ts",
+    "seed:demo": "npx playwright test demo-seed.spec.ts --workers=1"
   },
   "dependencies": {
     "@playwright/test": "^1.57.0",

--- a/seed-data/run-demo.sh
+++ b/seed-data/run-demo.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Start an isolated, fully-featured Syngrisi demo instance and seed it with a
+# feature tour (see tests/demo-seed.spec.ts). Reuses REAL test-app fixtures.
+#
+# Usage:
+#   seed-data/run-demo.sh                 # build if needed, start, seed
+#   PORT=3010 seed-data/run-demo.sh       # custom port
+#   SKIP_BUILD=1 seed-data/run-demo.sh    # skip the server/UI build
+#   seed-data/run-demo.sh stop            # stop the running demo server
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SYN="$ROOT/packages/syngrisi"
+PORT="${PORT:-3000}"
+DB="${DB:-SyngrisiDemo}"
+IMAGES="${IMAGES:-$SYN/.demo-images}"
+PIDFILE="$ROOT/seed-data/.demo-server.pid"
+LOG="$ROOT/seed-data/.demo-server.log"
+URL="http://localhost:$PORT"
+
+stop_server() {
+    if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
+        kill "$(cat "$PIDFILE")" && echo "Stopped demo server (pid $(cat "$PIDFILE"))."
+    else
+        # fall back to whatever listens on the port
+        pid=$(lsof -ti:"$PORT" 2>/dev/null || true)
+        [ -n "$pid" ] && kill "$pid" && echo "Stopped process on port $PORT (pid $pid)." || echo "No demo server running."
+    fi
+    rm -f "$PIDFILE"
+}
+
+if [ "${1:-}" = "stop" ]; then stop_server; exit 0; fi
+
+# 1. Build server + UI unless skipped
+if [ "${SKIP_BUILD:-}" != "1" ]; then
+    echo "==> Building server + UI..."
+    (cd "$SYN" && yarn build:server && yarn build:ui)
+fi
+
+# 2. (Re)start the isolated server with every feature flag on.
+#    Reset the DB *before* start so the server re-seeds default settings
+#    (ai_triage_provider etc.) via createInitialSettings() on boot.
+stop_server 2>/dev/null || true
+echo "==> Resetting demo database ($DB) and images..."
+mongosh "$DB" --quiet --eval "db.dropDatabase()" >/dev/null 2>&1 || true
+rm -rf "$IMAGES" && mkdir -p "$IMAGES"
+echo "==> Starting demo server on $URL (db=$DB)..."
+cd "$SYN"
+SYNGRISI_DB_URI="mongodb://127.0.0.1:27017/$DB" \
+SYNGRISI_IMAGES_PATH="$IMAGES/" \
+SYNGRISI_AUTH=false \
+SYNGRISI_TEST_MODE=true \
+SYNGRISI_APP_PORT="$PORT" \
+SYNGRISI_RCA=true \
+SYNGRISI_DISABLE_DOM_DATA=false \
+SYNGRISI_AI_TRIAGE_ENABLED=true \
+SYNGRISI_AI_TRIAGE_POLL_INTERVAL_MS=2000 \
+nohup node ./dist/server/server.js > "$LOG" 2>&1 &
+echo $! > "$PIDFILE"
+
+# 3. Wait until it answers
+echo -n "==> Waiting for server"
+for _ in $(seq 1 60); do
+    code=$(curl -s -o /dev/null -w "%{http_code}" "$URL/" 2>/dev/null || true)
+    if [ "$code" = "200" ] || [ "$code" = "302" ]; then echo " ready."; break; fi
+    echo -n "."; sleep 1
+done
+
+# 4. Make sure the seeder uses the CURRENT local playwright-sdk (with DOM/RCA
+#    support), not the older npm copy that a `file:` install may have left behind.
+cd "$ROOT/seed-data"
+[ -d node_modules ] || yarn install
+if [ "${SKIP_BUILD:-}" != "1" ]; then (cd "$ROOT/packages/playwright-sdk" && yarn build); fi
+LINK="$ROOT/seed-data/node_modules/@syngrisi/playwright-sdk"
+if [ ! -L "$LINK" ]; then
+    echo "==> Linking local @syngrisi/playwright-sdk into seed-data..."
+    rm -rf "$LINK"; mkdir -p "$(dirname "$LINK")"
+    ln -s ../../../packages/playwright-sdk "$LINK"
+fi
+
+# 5. Seed the feature tour (SYNGRISI_DISABLE_DOM_DATA=false so RCA DOM is sent)
+echo "==> Seeding demo data..."
+SYNGRISI_URL="$URL" SYNGRISI_API_KEY=123 SYNGRISI_DISABLE_DOM_DATA=false yarn seed:demo
+
+echo ""
+echo "============================================================"
+echo " Demo instance ready:  $URL"
+echo " Server pid:           $(cat "$PIDFILE")   (log: $LOG)"
+echo " Stop it with:         seed-data/run-demo.sh stop"
+echo "============================================================"

--- a/seed-data/tests/demo-seed.spec.ts
+++ b/seed-data/tests/demo-seed.spec.ts
@@ -1,0 +1,254 @@
+/**
+ * Feature-grouped demo seeder for Syngrisi.
+ *
+ * Each test seeds ONE product feature and names its run after that feature, so the
+ * runs list in the UI reads as a feature tour. All examples use REAL fixtures from
+ * the test app: images from packages/syngrisi/tests/files and RCA DOM pages from
+ * packages/syngrisi/e2e/fixtures/rca-test-scenarios.
+ *
+ * Requires a server started with (see run-demo.sh):
+ *   SYNGRISI_AUTH=false SYNGRISI_RCA=true SYNGRISI_AI_TRIAGE_ENABLED=true
+ * and this seeder run with SYNGRISI_DISABLE_DOM_DATA=false (so DOM is transmitted).
+ */
+import { test } from '@playwright/test';
+import { PlaywrightDriver } from '@syngrisi/playwright-sdk';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SYNGRISI_URL = (process.env.SYNGRISI_URL || 'http://localhost:3000').replace(/\/$/, '') + '/';
+const SYNGRISI_API_KEY = process.env.SYNGRISI_API_KEY || '123';
+
+const FILES = path.join(__dirname, '../../packages/syngrisi/tests/files');
+const RCA = path.join(__dirname, '../../packages/syngrisi/e2e/fixtures/rca-test-scenarios/html-changes');
+const img = (name: string) => fs.readFileSync(path.join(FILES, name));
+
+// Real image fixtures reused as demo examples.
+const A = img('A.png');            // canonical baseline
+const B = img('B.png');            // clearly-different actual (~5.7% diff)
+const LOW0 = img('low_diff_0.png'); // small-diff pair (tolerant demo)
+const LOW1 = img('low_diff_1.png');
+const ANTI_OFF = img('anti_off.png'); // anti-aliasing pair
+const ANTI_ON = img('anti_on.png');
+const PEOPLE1 = img('People1.png');
+const PEOPLE2 = img('People2.png');
+
+// --- raw HTTP helpers (auth is OFF on the demo server, so no auth header needed) ---
+async function api(pathname: string, method = 'GET', body?: unknown) {
+    const res = await fetch(SYNGRISI_URL + pathname.replace(/^\//, ''), {
+        method,
+        headers: body ? { 'Content-Type': 'application/json' } : {},
+        body: body ? JSON.stringify(body) : undefined,
+    });
+    const json = await res.json().catch(() => null);
+    return { status: res.status, json };
+}
+async function apiChecked(label: string, pathname: string, method: string, body?: unknown) {
+    const res = await api(pathname, method, body);
+    if (res.status < 200 || res.status >= 300) {
+        console.warn(`  ! ${label} → HTTP ${res.status}: ${JSON.stringify(res.json)?.slice(0, 160)}`);
+    }
+    return res;
+}
+const setFakeProvider = (fakeVerdict: string, fakeConfidence: number, fakeReason: string) =>
+    apiChecked('setProvider', 'v1/settings/ai_triage_provider', 'PATCH', {
+        value: { type: 'fake', model: 'fake', fakeVerdict, fakeConfidence, fakeReason },
+        enabled: true,
+    });
+const setAppTriagePolicy = (appId: string, body: unknown) => apiChecked('appPolicy', `v1/app/${appId}/triage-policy`, 'PATCH', body);
+const runTriage = (checkId: string) => apiChecked('triageRun', `ai/triage/${checkId}/run`, 'POST');
+const putBaseline = (baselineId: string, body: unknown) => apiChecked('putBaseline', `v1/baselines/${baselineId}`, 'PUT', body);
+
+/** Resolve the VRSBaseline document id from an accepted snapshot id (needed for PUT /v1/baselines/:id). */
+async function getBaselineId(snapshotId: string): Promise<string | undefined> {
+    const filter = encodeURIComponent(JSON.stringify({ snapshootId: snapshotId }));
+    const { json } = await api(`v1/baselines?filter=${filter}&limit=1`);
+    return json?.results?.[0]?._id;
+}
+
+type Ident = {
+    app: string; test: string; run: string; suite?: string; branch?: string;
+    tags?: string[]; os?: string; browserName?: string; viewport?: string;
+};
+
+function makeDriver(page: any, autoAccept = false) {
+    return new PlaywrightDriver({ page, url: SYNGRISI_URL, apiKey: SYNGRISI_API_KEY, autoAccept });
+}
+
+async function session(driver: PlaywrightDriver, id: Ident, suffix: string) {
+    await driver.startTestSession({
+        params: {
+            app: id.app, test: id.test, run: id.run,
+            runident: `${id.run}-${suffix}-${Date.now()}`,
+            branch: id.branch || 'main', suite: id.suite || 'Demo',
+            tags: id.tags || [], os: id.os || 'macOS',
+            browserName: id.browserName || 'chromium', browserVersion: '131',
+            viewport: id.viewport || '1920x1080',
+        },
+    });
+}
+
+/** Create a baseline check and accept it; returns the VRSBaseline id (for PUT ops) + app id. */
+async function makeBaseline(driver: PlaywrightDriver, id: Ident, checkName: string, image: Buffer) {
+    await session(driver, id, 'base');
+    const res: any = await driver.check({ checkName, imageBuffer: image, params: {} });
+    await driver.stopTestSession();
+    const snapshotId = res.actualSnapshotId;
+    await driver.acceptCheck({ checkId: res._id, baselineId: snapshotId });
+    const baselineId = await getBaselineId(snapshotId); // VRSBaseline._id, differs from snapshotId
+    return { baselineId, snapshotId, checkId: res._id, appId: res.app as string };
+}
+
+/** Submit an actual check against an existing baseline; returns the failed/passed check. */
+async function makeActual(driver: PlaywrightDriver, id: Ident, checkName: string, image: Buffer) {
+    await session(driver, id, 'actual');
+    const res: any = await driver.check({ checkName, imageBuffer: image, params: {} });
+    await driver.stopTestSession();
+    return res;
+}
+
+test.describe('Syngrisi Demo Seed', () => {
+    const APP = 'Demo Web App';
+
+    test('Passing', async ({ page }) => {
+        const d = makeDriver(page);
+        const id: Ident = { app: APP, test: 'Login Page', run: 'Passing', suite: 'Auth', tags: ['smoke'] };
+        await makeBaseline(d, id, 'Login Page', A);
+        await makeActual(d, id, 'Login Page', A); // identical → passed
+    });
+
+    test('Regression (failed diff)', async ({ page }) => {
+        const d = makeDriver(page);
+        const id: Ident = { app: APP, test: 'Dashboard', run: 'Regression', suite: 'Main', tags: ['smoke', 'critical'] };
+        await makeBaseline(d, id, 'Dashboard', A);
+        await makeActual(d, id, 'Dashboard', B); // ~5.7% diff → failed
+    });
+
+    test('New baselines', async ({ page }) => {
+        const d = makeDriver(page);
+        const id: Ident = { app: APP, test: 'Reports', run: 'New Baselines', suite: 'Analytics', tags: ['new'] };
+        // fresh, never accepted → status "new"
+        await session(d, id, 'new');
+        await d.check({ checkName: 'Reports · Overview', imageBuffer: PEOPLE1, params: {} });
+        await d.check({ checkName: 'Reports · Details', imageBuffer: PEOPLE2, params: {} });
+        await d.stopTestSession();
+    });
+
+    test('Match: Tolerant', async ({ page }) => {
+        const d = makeDriver(page);
+        const id: Ident = { app: APP, test: 'Pricing Table', run: 'Match · Tolerant', suite: 'Match Types' };
+        const { baselineId } = await makeBaseline(d, id, 'Pricing Table', LOW0);
+        if (baselineId) await putBaseline(baselineId, { matchType: 'tolerant', toleranceThreshold: 5 });
+        await makeActual(d, id, 'Pricing Table', LOW1); // small diff, tolerated
+    });
+
+    test('Match: Anti-aliasing', async ({ page }) => {
+        const d = makeDriver(page);
+        const id: Ident = { app: APP, test: 'Typography', run: 'Match · Anti-aliasing', suite: 'Match Types' };
+        const { baselineId } = await makeBaseline(d, id, 'Typography', ANTI_OFF);
+        if (baselineId) await putBaseline(baselineId, { matchType: 'antialiasing' });
+        await makeActual(d, id, 'Typography', ANTI_ON);
+    });
+
+    test('Ignore Regions', async ({ page }) => {
+        const d = makeDriver(page);
+        const id: Ident = { app: APP, test: 'Home Banner', run: 'Ignore Regions', suite: 'Match Types' };
+        const { baselineId } = await makeBaseline(d, id, 'Home Banner', A);
+        // Mask a region so the changed area is excluded from comparison.
+        if (baselineId) await putBaseline(baselineId, { ignoreRegions: JSON.stringify([{ left: 0, top: 0, right: 400, bottom: 200 }]) });
+        await makeActual(d, id, 'Home Banner', B);
+    });
+
+    test('AI Triage (verdicts)', async ({ page }) => {
+        const d = makeDriver(page);
+        const id: Ident = { app: APP, test: 'Checkout', run: 'AI Triage', suite: 'AI', tags: ['ai'] };
+        await makeBaseline(d, id, 'Checkout · Cart', A);
+        // Global triage is on via env (SYNGRISI_AI_TRIAGE_ENABLED=true). We drive verdicts
+        // synchronously via POST /ai/triage/:id/run and deliberately do NOT enable the app
+        // for the background scheduler, so each check gets exactly the verdict we set below.
+
+        // One failed check per verdict flavour, triaged deterministically via the fake provider.
+        const cases: Array<[string, string, number, string]> = [
+            ['Checkout · Cart', 'likely_bug', 9, 'Submit button overlaps the total'],
+            ['Checkout · Shipping', 'noise', 8, 'Timestamp text differs, cosmetic only'],
+            ['Checkout · Payment', 'intended_change', 8, 'New promo banner is an intended change'],
+            ['Checkout · Review', 'noise', 3, 'Low confidence — will be masked to unknown'],
+        ];
+        for (const [name, verdict, confidence, reason] of cases) {
+            // ensure a baseline exists for this check name, then fail it
+            if (name !== 'Checkout · Cart') await makeBaseline(d, { ...id, test: 'Checkout' }, name, A);
+            const actual = await makeActual(d, { ...id, test: 'Checkout' }, name, B);
+            await setFakeProvider(verdict, confidence, reason);
+            await runTriage(actual._id);
+        }
+    });
+
+    test('AI Auto-Accept (policy)', async ({ page }) => {
+        const d = makeDriver(page);
+        const id: Ident = { app: APP, test: 'Marketing', run: 'AI Auto-Accept', suite: 'AI', tags: ['ai'] };
+        const first = await makeBaseline(d, id, 'Marketing · Hero', A);
+        const appId = first.appId;
+        // Auto-accept policy is applied inside triageCheck (POST /ai/triage/:id/run), so it
+        // works without enabling the app for the scheduler.
+        if (appId) {
+            await setAppTriagePolicy(appId, {
+                triagePolicy: { policy: 'auto', autoAcceptThreshold: 9, autoAcceptVerdicts: ['noise', 'intended_change'] },
+            });
+        }
+        // noise@10 → auto-accepted
+        const a1 = await makeActual(d, id, 'Marketing · Hero', B);
+        await setFakeProvider('noise', 10, 'Font smoothing only — safe to accept');
+        await runTriage(a1._id);
+        // likely_bug@10 → never auto-accepted (stays failed for human review)
+        await makeBaseline(d, id, 'Marketing · Footer', A);
+        const a2 = await makeActual(d, id, 'Marketing · Footer', B);
+        await setFakeProvider('likely_bug', 10, 'Footer links broken');
+        await runTriage(a2._id);
+    });
+
+    test('RCA (DOM root cause)', async ({ page }) => {
+        const d = makeDriver(page);
+        const id: Ident = { app: APP, test: 'Content Page', run: 'RCA', suite: 'RCA', tags: ['rca'] };
+        const pairs: Array<[string, string, string]> = [
+            ['Content · Added elements', 'base.html', 'added-elements.html'],
+            ['Content · Text change', 'base.html', 'text-change.html'],
+            ['Content · Broken layout', 'base.html', 'broken-layout.html'],
+        ];
+        for (const [checkName, baseHtml, changedHtml] of pairs) {
+            // Baseline: real DOM + screenshot of the base page.
+            // collectDom captures the live DOM; skipDomData:false forces transmission.
+            await page.goto('file://' + path.join(RCA, baseHtml));
+            await session(d, id, 'rca-base');
+            const base: any = await d.check({ checkName, imageBuffer: await page.screenshot(), params: { skipDomData: false }, collectDom: true });
+            await d.stopTestSession();
+            await d.acceptCheck({ checkId: base._id, baselineId: base.actualSnapshotId });
+            // Actual: changed page → failed check with DOM, so the RCA panel has data to diff
+            await page.goto('file://' + path.join(RCA, changedHtml));
+            await session(d, id, 'rca-actual');
+            await d.check({ checkName, imageBuffer: await page.screenshot(), params: { skipDomData: false }, collectDom: true });
+            await d.stopTestSession();
+        }
+    });
+
+    test('Cross-browser & viewports', async ({ page }) => {
+        const d = makeDriver(page);
+        const matrix: Array<[string, string, string]> = [
+            ['chromium', '1920x1080', 'macOS'],
+            ['firefox', '1366x768', 'Windows'],
+            ['webkit', '390x844', 'iOS'],
+        ];
+        for (const [browserName, viewport, os] of matrix) {
+            const id: Ident = { app: APP, test: 'Landing', run: 'Cross-browser', suite: 'Compatibility', browserName, viewport, os };
+            await makeBaseline(d, id, `Landing · ${browserName}`, A);
+            await makeActual(d, id, `Landing · ${browserName}`, browserName === 'firefox' ? B : A);
+        }
+    });
+
+    test('Branches', async ({ page }) => {
+        const d = makeDriver(page);
+        for (const branch of ['main', 'develop', 'feature/new-nav', 'release/v2.0']) {
+            const id: Ident = { app: APP, test: 'Nav Bar', run: 'Branches', suite: 'Branching', branch };
+            await makeBaseline(d, id, `Nav Bar · ${branch}`, A);
+            await makeActual(d, id, `Nav Bar · ${branch}`, branch.startsWith('feature') ? B : A);
+        }
+    });
+});


### PR DESCRIPTION
Adds a `/demo-seed` skill that boots an isolated, fully-featured Syngrisi demo instance and seeds it with a feature tour built from REAL test-app fixtures. Features are grouped one-per-run so the runs list reads as a tour.

## Contents
- `seed-data/run-demo.sh` — drops+starts an isolated server (separate DB/images, auth off, `SYNGRISI_RCA`/`SYNGRISI_AI_TRIAGE_ENABLED`/DOM on), links the local `@syngrisi/playwright-sdk` (npm copy is too old for DOM/RCA), seeds, prints the URL. `run-demo.sh stop` to stop.
- `seed-data/tests/demo-seed.spec.ts` — one independent `test()` per feature/run: Passing, Regression, New Baselines, Match·Tolerant, Match·Anti-aliasing, Ignore Regions, AI Triage (deterministic fake-provider verdicts via `POST /ai/triage/:id/run`), AI Auto-Accept, RCA (live DOM diff), Cross-browser, Branches.
- `.claude/skills/demo-seed/SKILL.md` — usage + the feature tour.

## Verified locally
`SKIP_BUILD=1 seed-data/run-demo.sh` → 11/11 seeder tests green; 44 checks (8 passed / 13 failed / 23 new); 6 AI verdicts (likely_bug×2, noise×3, intended_change×1), 1 auto-accepted; RCA DOM endpoint returns 200.

Tooling only — no package/runtime code touched, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)