### PR TITLE
feat: roadmap batch — webhooks, PR commit-status, branch baseline fallback, MCP server, time machine, private AI, Python SDK

### DIFF
--- a/.changeset/baseline-time-machine.md
+++ b/.changeset/baseline-time-machine.md
@@ -1,0 +1,5 @@
+---
+"@syngrisi/syngrisi": minor
+---
+
+Add a baseline "time machine": a history slider over a check's accepted baselines (`GET /v1/baselines/history`), with an optional AI-generated one-line summary of what changed between two consecutive baselines (`POST /v1/baselines/history-summary`, reusing the configured AI triage provider; degrades to a plain slider when no provider is configured). New "History" action on the Baselines table opens a modal with the slider and prev/next controls.

--- a/.changeset/branch-baseline-fallback.md
+++ b/.changeset/branch-baseline-fallback.md
@@ -1,0 +1,5 @@
+---
+"@syngrisi/syngrisi": minor
+---
+
+Add read-time baseline fallback to a project's configured main branch: when a check on another branch has no accepted baseline of its own, it is now compared against the main branch's accepted baseline instead of landing as `new`/`not_accepted`. Configure it per project via the new `mainBranch` field (Admin → AI → Projects settings, or `PATCH /v1/app/:id/triage-policy`). Accepting stays branch-scoped — a check's own branch still gets its own baseline on accept. Empty/unset `mainBranch` preserves today's behavior.

--- a/.changeset/curly-mcp-server.md
+++ b/.changeset/curly-mcp-server.md
@@ -1,0 +1,5 @@
+---
+"@syngrisi/mcp": minor
+---
+
+New package: `@syngrisi/mcp` — an official Model Context Protocol server so AI coding agents (Claude Code, Cursor, ...) can list runs, inspect run status, view baseline/actual/diff images, and accept failed checks directly from the IDE.

--- a/.changeset/github-commit-status.md
+++ b/.changeset/github-commit-status.md
@@ -1,0 +1,8 @@
+---
+"@syngrisi/syngrisi": minor
+"@syngrisi/core-api": minor
+"@syngrisi/playwright-sdk": minor
+"@syngrisi/wdio-sdk": minor
+---
+
+Add GitHub commit-status integration: an optional `commit` param on `startSession` (SDKs and core-api) is persisted on the Run, and a session's outcome (pending/success/failure) is reported back to GitHub via `POST /repos/{owner}/{repo}/statuses/{sha}` with a deep link to the run's grid. Configure via `SYNGRISI_GITHUB_TOKEN`, `SYNGRISI_GITHUB_REPO`, `SYNGRISI_PUBLIC_URL` (and optional `SYNGRISI_GITHUB_API_URL`); dormant (zero requests) unless all of these plus a run's `commit` are set. See `docs/environment_variables.md`.

--- a/.changeset/private-ai-docker-profile.md
+++ b/.changeset/private-ai-docker-profile.md
@@ -1,0 +1,5 @@
+---
+"@syngrisi/syngrisi": minor
+---
+
+"Private AI" out of the box: `docker compose --profile ai up` now brings up a bundled Ollama service with a vision model (`OLLAMA_MODEL`, default `gemma4:12b`) for AI Triage — zero API keys, zero screenshot egress. The model is pulled by a one-shot `ollama-pull` helper into a persistent named volume, so the Ollama healthcheck never blocks on a multi-GB download. The triage provider can now also be seeded from env via `SYNGRISI_AI_TRIAGE_PROVIDER_JSON` (raw JSON: `type`, `baseUrl`, `apiKey`, `model`, …), which is applied to the `ai_triage_provider` setting on startup with env-over-admin precedence — headless/CI provisioning without touching the admin UI. Documented in `docs/AI_FEATURES.md` ("Private AI with Ollama").

--- a/.changeset/webhooks-management.md
+++ b/.changeset/webhooks-management.md
@@ -1,0 +1,5 @@
+---
+"@syngrisi/syngrisi": minor
+---
+
+Add webhooks management: a CRUD API (`GET/POST/PATCH/DELETE /v1/webhooks`) and admin UI to register, enable/disable and delete webhooks on top of the existing delivery engine, plus a new `test.finished` event fired when a test session ends. See `packages/syngrisi/docs/WEBHOOKS.md`.

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,39 @@
+# Requires the PyPI project `syngrisi-core-api` to have GitHub trusted
+# publishing configured by a maintainer.
+#
+# Manual trigger only — NOT tag-based, and intentionally decoupled from the
+# npm/changesets release cycle in `.github/workflows/release.yml`.
+name: Publish Python SDK
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write # Required for OIDC trusted publishing to PyPI
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/core-api-python
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/core-api-python/dist

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ expensive, send your screenshots to someone else's servers, and lock you in.
 - 🤖 **Root Cause Analysis** _(beta)_ — captures a DOM snapshot alongside each screenshot to help explain **why** a check changed.
 - 🔐 **Auth, roles & SSO** — username/password, API keys, plus OAuth2 / SAML 2.0 single sign-on and an admin panel.
 - 🧩 **Plugin system & rich configuration** — extend behaviour and tune everything through environment variables.
+- 🔔 **Webhooks** — check/test lifecycle events with secret signing.
 - 🐳 **Self-hosted & Docker-ready** — Express + MongoDB backend, React + Mantine UI.
 
 ## 📸 Screenshots

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ stack, it's built for you.
 packages/
 ├── syngrisi/                              # Main application (Express + React)
 ├── core-api/                              # Framework-agnostic REST client
+├── core-api-python/                       # Python REST client (+ Playwright driver)
 ├── playwright-sdk/                        # Playwright SDK
 ├── wdio-sdk/                              # WebdriverIO SDK
 ├── wdio-syngrisi-cucumber-service/        # WebdriverIO + Cucumber service

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ expensive, send your screenshots to someone else's servers, and lock you in.
 - 🔐 **Auth, roles & SSO** — username/password, API keys, plus OAuth2 / SAML 2.0 single sign-on and an admin panel.
 - 🧩 **Plugin system & rich configuration** — extend behaviour and tune everything through environment variables.
 - 🔔 **Webhooks** — check/test lifecycle events with secret signing.
+- ✅ **GitHub commit status** — report a run's pass/fail state straight to the PR, with a deep link back to the grid.
 - 🐳 **Self-hosted & Docker-ready** — Express + MongoDB backend, React + Mantine UI.
 
 ## 📸 Screenshots

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ expensive, send your screenshots to someone else's servers, and lock you in.
 - 🧠 **AI Triage** _(beta)_ — a vision-LLM classifies each failed check (intended change / likely bug / noise) with a confidence score; auto-accept policies, per-project prompts & verdicts, and a fully self-hosted local-model option via Ollama.
 - 🎯 **AI Match** _(beta)_ — from one failed check, instantly find the **same visual change** on every other resolution and browser, ranked by a similarity score — review the whole cluster of "one bug, many viewports" in a single pass. 100% local, no model required.
 - 🤖 **Root Cause Analysis** _(beta)_ — captures a DOM snapshot alongside each screenshot to help explain **why** a check changed.
+- 🕰️ **Baseline Time Machine** — scrub through a check's accepted baselines over time with a history slider, with an optional AI-generated one-line summary of what changed between steps.
 - 🔐 **Auth, roles & SSO** — username/password, API keys, plus OAuth2 / SAML 2.0 single sign-on and an admin panel.
 - 🧩 **Plugin system & rich configuration** — extend behaviour and tune everything through environment variables.
 - 🐳 **Self-hosted & Docker-ready** — Express + MongoDB backend, React + Mantine UI.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ expensive, send your screenshots to someone else's servers, and lock you in.
 - 🔐 **Auth, roles & SSO** — username/password, API keys, plus OAuth2 / SAML 2.0 single sign-on and an admin panel.
 - 🧩 **Plugin system & rich configuration** — extend behaviour and tune everything through environment variables.
 - 🐳 **Self-hosted & Docker-ready** — Express + MongoDB backend, React + Mantine UI.
+- 🤖 **MCP server** — let AI agents query runs, view diffs and accept checks from the IDE.
 
 ## 📸 Screenshots
 
@@ -216,6 +217,7 @@ packages/
 ├── wdio-syngrisi-cucumber-service/        # WebdriverIO + Cucumber service
 ├── wdio-cucumber-viewport-logger-service/ # In-viewport step logger
 ├── node-resemble.js/                      # Image comparison library
+├── mcp/                                   # MCP server for AI agents
 └── create-sy/                             # `npm init sy` project scaffolder
 ```
 
@@ -226,6 +228,7 @@ packages/
 ## 📚 Documentation
 
 - 📖 [Main App Guide](packages/syngrisi/README.md)
+- 🤖 [MCP Server for AI Agents](packages/mcp/README.md)
 - 🤖 [AI Features](packages/syngrisi/docs/AI_FEATURES.md) · [Root Cause Analysis](packages/syngrisi/docs/RCA.md)
 - 🧩 [Plugins](packages/syngrisi/docs/PLUGINS.md)
 - ⚙️ [Environment Variables](packages/syngrisi/docs/environment_variables.md)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ expensive, send your screenshots to someone else's servers, and lock you in.
   OpenAI-compatible / Anthropic / Gemini endpoint.
 - 🎛️ **Yours to tune** — per-project verdicts, fully editable prompt with `{{placeholders}}`,
   few-shot example images, and a manual queue (restart / cancel) grouped by run.
+- 🐳 **Private AI out of the box** — `docker compose --profile ai up` starts a bundled
+  **Ollama** with a vision model and wires triage to it via env: zero API keys, zero
+  screenshot egress. See [Private AI with Ollama](packages/syngrisi/docs/AI_FEATURES.md#private-ai-with-ollama-docker-profile).
 
 > Enabled per project, **off by default**. See [AI Triage docs](packages/syngrisi/AI_TRIAGE.md).
 

--- a/packages/core-api-python/README.md
+++ b/packages/core-api-python/README.md
@@ -6,6 +6,12 @@ functional parity. SDK version: **3.6.0**.
 ## Install
 
 ```bash
+pip install syngrisi-core-api
+```
+
+For local development:
+
+```bash
 python3 -m venv .venv
 .venv/bin/pip install -e .            # runtime (requests)
 .venv/bin/pip install -e ".[dev]"     # + test deps (responses, pytest)
@@ -54,6 +60,28 @@ Method names are Pythonic (`start_session`, `core_check`, `get_baselines`,
 aliases (`startSession`, `coreCheck`, `getBaselines`, `transformOs`, ...).
 Wire behaviour (field names, URL shapes, header names) is identical to the JS
 package.
+
+## Playwright quickstart
+
+```python
+from syngrisi_core_api.playwright_driver import PlaywrightDriver
+
+driver = PlaywrightDriver(page, "http://localhost:3000/", "your-api-key")
+
+driver.start_test_session({
+    "run": "run-id", "suite": "suite-name", "runident": "run-identifier",
+    "name": "homepage test", "app": "MyProject", "branch": "main",
+})
+
+driver.check("homepage")  # image_buffer defaults to page.screenshot()
+
+driver.stop_test_session()
+```
+
+`PlaywrightDriver` is a minimal port of the JS `@syngrisi/playwright-sdk`
+driver's session/check surface only. Not yet ported: DOM collection for RCA,
+`setIgnoreRegions`, and auto-accept — see
+`syngrisi_core_api/playwright_driver.py` docstring for details.
 
 ## Public surface
 

--- a/packages/core-api-python/pyproject.toml
+++ b/packages/core-api-python/pyproject.toml
@@ -12,9 +12,16 @@ license = { text = "MIT" }
 authors = [{ name = "Viktar Silakou" }]
 keywords = ["visual", "regression", "test", "SDK"]
 dependencies = ["requests>=2.25"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+]
 
 [project.optional-dependencies]
 dev = ["responses>=0.23", "pytest>=7.0"]
+
+[project.urls]
+Homepage = "https://github.com/syngrisi/syngrisi"
 
 [tool.setuptools.packages.find]
 include = ["syngrisi_core_api*"]

--- a/packages/core-api-python/syngrisi_core_api/playwright_driver.py
+++ b/packages/core-api-python/syngrisi_core_api/playwright_driver.py
@@ -1,0 +1,145 @@
+"""Minimal Playwright driver for the Syngrisi Python SDK.
+
+Ports the core session/check surface of the JS `PlaywrightDriver`
+(`packages/playwright-sdk/src/PlaywrightDriver.ts`), specifically:
+
+- ``start_test_session`` / ``stop_test_session`` — session lifecycle
+  (mirrors ``PlaywrightDriver.ts:99-169``).
+- ``check`` — screenshot capture + param merging: the session's
+  ``testId``, ``app``, ``branch``, ``suite``, ``browser``/``browserName``,
+  ``browserVersion``, ``browserFullVersion`` and ``os`` are attached to
+  every check, while ``viewport`` is re-read live and explicit
+  ``params`` override the computed values (mirrors
+  ``PlaywrightDriver.ts:259-330``).
+
+The ``page`` argument is duck-typed: any object exposing ``screenshot()``
+(returning bytes) and, optionally, ``viewport_size`` /
+``context.browser.browser_type.name`` / ``context.browser.version`` for
+best-effort environment auto-detection works. No dependency on the
+``playwright`` package itself is required.
+
+NOT ported (deferred — see plan 001, "Do NOT port" list):
+
+- DOM collection for RCA (JS ``collectDomDump``).
+- ``setIgnoreRegions`` / the ``Region`` helper class.
+- Auto-accept of new baselines (JS ``autoAccept`` / ``acceptCheck`` wiring).
+"""
+
+import hashlib
+
+from .api import SyngrisiApi
+
+
+class PlaywrightDriver:
+    """Wraps :class:`SyngrisiApi` with a Playwright-friendly session/check API."""
+
+    def __init__(self, page, url, api_key=None, headers=None):
+        self.page = page
+        self.api = SyngrisiApi({"url": url, "apiKey": api_key, "headers": headers})
+        self._test = {}
+
+    # ----- environment auto-detection (best-effort, no extra deps) ---------
+
+    def _detect_viewport(self):
+        size = getattr(self.page, "viewport_size", None)
+        if callable(size):
+            size = size()
+        if isinstance(size, dict) and size.get("width") and size.get("height"):
+            return f"{size['width']}x{size['height']}"
+        return "0x0"
+
+    def _detect_browser_name(self):
+        try:
+            return self.page.context.browser.browser_type.name
+        except AttributeError:
+            return "unknown"
+
+    def _detect_browser_version(self):
+        try:
+            return self.page.context.browser.version
+        except AttributeError:
+            return "0"
+
+    @staticmethod
+    def _detect_os():
+        return "UNKNOWN"
+
+    # ----- session lifecycle -------------------------------------------------
+
+    def start_test_session(self, params):
+        """Starts a test session; stores the merged session params for `check()`.
+
+        Mirrors ``PlaywrightDriver.ts`` `startTestSession` — fields not
+        provided in ``params`` fall back to environment auto-detection.
+        Returns the session response (or raises if the API returns an
+        error object).
+        """
+        params = dict(params or {})
+
+        self._test = {
+            "os": params.get("os") or self._detect_os(),
+            "viewport": params.get("viewport") or self._detect_viewport(),
+            "browser": params.get("browser") or self._detect_browser_name(),
+            "browserVersion": params.get("browserVersion") or self._detect_browser_version(),
+            "browserFullVersion": params.get("browserFullVersion") or self._detect_browser_version(),
+            "name": params.get("name"),
+            "app": params.get("app"),
+            "run": params.get("run"),
+            "branch": params.get("branch"),
+            "runident": params.get("runident"),
+            "suite": params.get("suite"),
+            "tags": params.get("tags"),
+        }
+
+        result = self.api.start_session(self._test)
+        if isinstance(result, dict) and result.get("error"):
+            raise RuntimeError(f"Cannot start session: {result}")
+
+        self._test["testId"] = result.get("_id") if isinstance(result, dict) else None
+        return result
+
+    def stop_test_session(self):
+        """Stops the current test session using the stored test id."""
+        test_id = self._test.get("testId")
+        self._test["testId"] = None
+        result = self.api.stop_session(test_id)
+        if isinstance(result, dict) and result.get("error"):
+            raise RuntimeError(f"Cannot stop session: {result}")
+        return result
+
+    # ----- check ---------------------------------------------------------------
+
+    def check(self, check_name, image_buffer=None, params=None):
+        """Submits a visual check.
+
+        ``image_buffer`` defaults to ``page.screenshot()`` when omitted.
+        Session params (``testId``, ``app``, ``branch``, ``suite``,
+        ``browserName``, ``browserVersion``, ``browserFullVersion``,
+        ``os``) are attached automatically; ``viewport`` is re-read live;
+        explicit ``params`` override the computed values.
+        """
+        if not self._test.get("testId"):
+            raise RuntimeError(
+                "The test id is empty, the session may not have started yet: "
+                f"check name: '{check_name}'"
+            )
+
+        if image_buffer is None:
+            image_buffer = self.page.screenshot()
+
+        opts = {
+            "name": check_name,
+            "viewport": self._detect_viewport(),
+            "browserName": self._test.get("browser"),
+            "os": self._test.get("os"),
+            "app": self._test.get("app"),
+            "branch": self._test.get("branch"),
+            "testId": self._test.get("testId"),
+            "suite": self._test.get("suite"),
+            "browserVersion": self._test.get("browserVersion"),
+            "browserFullVersion": self._test.get("browserFullVersion"),
+            "hashCode": hashlib.sha512(image_buffer).hexdigest(),
+        }
+        opts.update(params or {})
+
+        return self.api.core_check(image_buffer, opts)

--- a/packages/core-api-python/tests/test_playwright_driver.py
+++ b/packages/core-api-python/tests/test_playwright_driver.py
@@ -1,0 +1,133 @@
+import responses
+
+from syngrisi_core_api.playwright_driver import PlaywrightDriver
+
+
+class FakePage:
+    """Duck-typed stand-in for a Playwright `Page` object."""
+
+    def __init__(self, screenshot_bytes=b"fake-png-bytes"):
+        self._screenshot_bytes = screenshot_bytes
+        self.screenshot_calls = 0
+        self.viewport_size = {"width": 1200, "height": 800}
+
+    def screenshot(self):
+        self.screenshot_calls += 1
+        return self._screenshot_bytes
+
+
+def _session_params():
+    return {
+        "run": "run-id",
+        "suite": "suite-name",
+        "runident": "run-identifier",
+        "name": "test-name",
+        "app": "MyProject",
+        "branch": "main",
+        "os": "macOS",
+        "viewport": "1200x800",
+        "browser": "chrome",
+        "browserVersion": "113",
+        "browserFullVersion": "113.0.0.0",
+    }
+
+
+def _start_session(driver):
+    responses.add(
+        responses.POST,
+        "http://localhost:3000/v1/client/startSession",
+        json={"_id": "0123456789abcdef01234567"},
+        status=200,
+    )
+    return driver.start_test_session(_session_params())
+
+
+@responses.activate
+def test_check_merges_session_params():
+    page = FakePage()
+    driver = PlaywrightDriver(page, "http://localhost:3000/", "api-key")
+    _start_session(driver)
+
+    responses.add(
+        responses.POST,
+        "http://localhost:3000/v1/client/createCheck",
+        json={"status": "passed", "_id": "abc"},
+        status=200,
+    )
+
+    driver.check("homepage", image_buffer=b"image-bytes")
+
+    check_request = responses.calls[-1].request
+    body = check_request.body
+    body_bytes = body if isinstance(body, bytes) else str(body).encode()
+
+    assert b'name="testid"\r\n\r\n0123456789abcdef01234567' in body_bytes
+    assert b'name="appName"\r\n\r\nMyProject' in body_bytes
+    assert b'name="branch"\r\n\r\nmain' in body_bytes
+    assert b'name="viewport"\r\n\r\n1200x800' in body_bytes
+    assert b'name="browserName"\r\n\r\nchrome' in body_bytes
+    assert b'name="os"\r\n\r\nmacOS' in body_bytes
+    assert b'name="suitename"\r\n\r\nsuite-name' in body_bytes
+
+
+@responses.activate
+def test_check_auto_captures_screenshot_when_image_buffer_none():
+    page = FakePage(screenshot_bytes=b"auto-screenshot-bytes")
+    driver = PlaywrightDriver(page, "http://localhost:3000/", "api-key")
+    _start_session(driver)
+
+    # Phase 1 (hash-only) asks for the file; phase 2 receives it.
+    responses.add(
+        responses.POST,
+        "http://localhost:3000/v1/client/createCheck",
+        json={"status": "requiredFileData"},
+        status=200,
+    )
+    responses.add(
+        responses.POST,
+        "http://localhost:3000/v1/client/createCheck",
+        json={"status": "new", "_id": "abc"},
+        status=200,
+    )
+
+    driver.check("homepage")
+
+    # The driver must call page.screenshot() exactly once even though the
+    # API needs two round-trips internally.
+    assert page.screenshot_calls == 1
+    body = responses.calls[-1].request.body
+    body_bytes = body if isinstance(body, bytes) else str(body).encode()
+    assert b"auto-screenshot-bytes" in body_bytes
+
+
+@responses.activate
+def test_stop_test_session_uses_stored_test_id():
+    page = FakePage()
+    driver = PlaywrightDriver(page, "http://localhost:3000/", "api-key")
+    _start_session(driver)
+
+    responses.add(
+        responses.POST,
+        "http://localhost:3000/v1/client/stopSession/0123456789abcdef01234567",
+        json={"_id": "0123456789abcdef01234567", "status": "stopped"},
+        status=200,
+    )
+
+    result = driver.stop_test_session()
+
+    assert result["status"] == "stopped"
+    assert driver._test["testId"] is None
+    stop_call_urls = [c.request.url for c in responses.calls]
+    assert any("stopSession/0123456789abcdef01234567" in u for u in stop_call_urls)
+
+
+@responses.activate
+def test_check_raises_when_session_not_started():
+    page = FakePage()
+    driver = PlaywrightDriver(page, "http://localhost:3000/", "api-key")
+
+    try:
+        driver.check("homepage", image_buffer=b"image-bytes")
+        assert False, "expected RuntimeError"
+    except RuntimeError as e:
+        assert "test id is empty" in str(e)

--- a/packages/core-api/schemas/SyngrisiApi.schema.ts
+++ b/packages/core-api/schemas/SyngrisiApi.schema.ts
@@ -124,6 +124,7 @@ export const ApiSessionParamsSchema = z.object({
     app: z.string(),
     tags: z.array(z.string()).optional(),
     branch: z.string(),
+    commit: z.string().regex(/^[0-9a-fA-F]{7,40}$/).optional(), // Git commit SHA, used to report a commit status back to GitHub
 })
 
 export type ApiSessionParams = z.infer<typeof ApiSessionParamsSchema>;

--- a/packages/core-api/src/SyngrisiApi.ts
+++ b/packages/core-api/src/SyngrisiApi.ts
@@ -162,6 +162,7 @@ class SyngrisiApi {
             // optional
             if (params.tags) form.append('tags', JSON.stringify(params.tags))
             if (params.branch) form.append('branch', params.branch)
+            if (params.commit) form.append('commit', params.commit)
 
             return got.post(this.url('startSession'), {
                 body: form,

--- a/packages/mcp/.gitignore
+++ b/packages/mcp/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.idea
+*.bak
+dist
+coverage

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,86 @@
+# @syngrisi/mcp
+
+Official [Model Context Protocol](https://modelcontextprotocol.io) server for
+[Syngrisi](https://github.com/syngrisi/syngrisi) — the open-source, self-hosted visual
+testing platform. It lets AI coding agents (Claude Code, Cursor, ...) ask "what broke in
+the last run?", look at baseline/actual/diff images, and accept checks — straight from
+the IDE, over stdio, without touching the browser UI.
+
+This is a thin adapter over your running Syngrisi instance's REST API. It does not run
+tests itself — see `@syngrisi/playwright-sdk` / `@syngrisi/wdio-sdk` for that, or the
+internal MCP *test engine* documented in `packages/syngrisi/docs/agent/guides/mcp_test_engine_using.md`
+for driving BDD e2e steps.
+
+## Install & run
+
+No install needed — run it directly with `npx`:
+
+```shell
+npx -y @syngrisi/mcp --url http://localhost:3000 --api-key <your-api-key>
+```
+
+`--api-key` can be omitted for instances started with `SYNGRISI_AUTH=false`.
+
+### Claude Code
+
+```shell
+claude mcp add syngrisi -- npx -y @syngrisi/mcp --url http://localhost:3000 --api-key <your-api-key>
+```
+
+### Cursor (`.cursor/mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "syngrisi": {
+      "command": "npx",
+      "args": ["-y", "@syngrisi/mcp", "--url", "http://localhost:3000", "--api-key", "<your-api-key>"]
+    }
+  }
+}
+```
+
+## Configuration
+
+Configuration is env-only (plus two CLI flags that override the env) — there are no
+config files.
+
+| Env var | CLI flag | Required | Description |
+|---|---|---|---|
+| `SYNGRISI_URL` | `--url` | Yes | Base URL of the Syngrisi instance, e.g. `http://localhost:3000` |
+| `SYNGRISI_API_KEY` | `--api-key` | No | API key; omit for instances with `SYNGRISI_AUTH=false` |
+
+## Tools
+
+| Tool | Arguments | Description |
+|---|---|---|
+| `list_runs` | `app?`, `limit?` | Recent runs (id, name, app, createdDate), newest-first |
+| `get_run_status` | `runId?` | Aggregate status of a run: total/passed/failed/new tests + failed check names. Defaults to the latest run |
+| `get_failed_checks` | `runId?`, `limit?` | Failed checks in a run: name, browser, viewport, os, branch, mismatch %, fail reasons |
+| `get_check` | `checkId` | Full details of one check, including snapshot filenames and image URLs |
+| `get_check_images` | `checkId`, `which?` (`baseline`\|`actual`\|`diff`\|`all`) | Inline images (base64 PNG) for a check. Refuses images over 8MB |
+| `accept_check` | `checkId`, `baselineId?` | Accept a check, promoting its actual snapshot (or a given `baselineId`) to the new baseline |
+
+Every tool returns a compact human-readable text summary first, then structured JSON in
+the same response. Errors never throw — they come back as `isError: true` with a text
+message. The API key is never included in any tool output or log.
+
+### Known limitation
+
+A few Syngrisi REST endpoints used here (`GET /v1/runs`, `GET /v1/snapshots`) are
+session-auth only in some server versions and don't accept the `apikey` header — this
+package still sends it (harmless), and works around the gap for check-related tools by
+requesting `populate=baselineId,actualSnapshotId,diffId` on `GET /v1/checks` (which does
+accept an API key) instead of calling `/v1/snapshots` separately. `list_runs` /
+`get_run_status`'s default-latest-run resolution may not work against an auth-enabled
+instance when using an API key only, without an authenticated session; it works
+correctly when `SYNGRISI_AUTH=false` or when called from an already-authenticated
+client.
+
+## Development
+
+```shell
+yarn build       # compile to dist/
+yarn test        # node:test against a stubbed Syngrisi server
+yarn smoke:live   # end-to-end smoke against a real, running Syngrisi instance
+```

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@syngrisi/mcp",
+  "version": "0.1.0",
+  "description": "Official Syngrisi MCP server — let AI agents (Claude Code, Cursor) query runs, inspect visual diffs, and accept checks from the IDE.",
+  "main": "dist/cli.js",
+  "types": "dist/cli.d.ts",
+  "private": false,
+  "bin": {
+    "syngrisi-mcp": "dist/cli.js"
+  },
+  "scripts": {
+    "build": "run-s clean compile",
+    "clean": "rimraf tsconfig.tsbuildinfo ./dist ./coverage",
+    "compile": "tsc -p ./tsconfig.json",
+    "test": "tsx --test tests/server.test.ts",
+    "smoke:live": "tsx tests/smoke.live.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/syngrisi/syngrisi",
+    "directory": "packages/mcp"
+  },
+  "keywords": [
+    "visual",
+    "regression",
+    "test",
+    "mcp",
+    "model-context-protocol",
+    "ai-agent",
+    "claude",
+    "cursor"
+  ],
+  "author": "Viktar Silakou",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/syngrisi/syngrisi/issues"
+  },
+  "homepage": "https://github.com/syngrisi/syngrisi/tree/main/packages/mcp",
+  "engines": {
+    "node": ">=22.19.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "@syngrisi/core-api": "^3.10.1",
+    "@types/node": "^26.0.0",
+    "rimraf": "^6.1.3",
+    "npm-run-all": "^4.1.5",
+    "typescript": "^6.0.3",
+    "tsx": "^4.22.4"
+  }
+}

--- a/packages/mcp/src/api.ts
+++ b/packages/mcp/src/api.ts
@@ -1,0 +1,193 @@
+/**
+ * Thin fetch-based client for the Syngrisi REST API.
+ *
+ * Deliberately small and dependency-free (Node 22 has a global `fetch`): the MCP
+ * server only needs a handful of read endpoints plus "accept check" and the static
+ * snapshot image route, so pulling in `@syngrisi/core-api` (built for SDK authors
+ * pushing checks) would be the wrong tool for the job.
+ */
+
+export interface SyngrisiClientConfig {
+    /** Base URL of the Syngrisi instance, e.g. "http://localhost:3000" */
+    url: string;
+    /** Optional API key. Instances started with SYNGRISI_AUTH=false need none. */
+    apiKey?: string;
+}
+
+export interface PaginatedResult<T> {
+    results: T[];
+    page: number;
+    limit: number;
+    totalPages: number;
+    totalResults: number;
+    timestamp: number | string;
+}
+
+export interface RunDoc {
+    id: string;
+    _id: string;
+    name: string;
+    app: string;
+    ident: string;
+    createdDate: string;
+    updatedDate?: string;
+}
+
+export interface TestDoc {
+    id: string;
+    _id: string;
+    name: string;
+    status: string;
+    branch?: string;
+    browserName?: string;
+    browserVersion?: string;
+    viewport?: string;
+    os?: string;
+    run?: string;
+    checks?: string[];
+}
+
+export interface SnapshotDoc {
+    id: string;
+    _id: string;
+    name: string;
+    filename?: string;
+    path?: string;
+    imghash?: string;
+}
+
+export interface CheckDoc {
+    id: string;
+    _id: string;
+    name: string;
+    test: string;
+    suite: string;
+    app: string;
+    run: string;
+    branch?: string;
+    status: string[];
+    browserName?: string;
+    browserVersion?: string;
+    browserFullVersion?: string;
+    viewport?: string;
+    os?: string;
+    result?: string;
+    failReasons?: string[];
+    markedAs?: string;
+    createdDate?: string;
+    updatedDate?: string;
+    baselineId?: string | SnapshotDoc | null;
+    actualSnapshotId?: string | SnapshotDoc | null;
+    diffId?: string | SnapshotDoc | null;
+}
+
+export interface AppDoc {
+    id: string;
+    _id: string;
+    name: string;
+}
+
+export interface ListOptions {
+    limit?: number;
+    sortBy?: string;
+    populate?: string;
+}
+
+export class SyngrisiApiError extends Error {
+    constructor(message: string, public status?: number) {
+        super(message);
+        this.name = 'SyngrisiApiError';
+    }
+}
+
+/** Resolve a snapshot id field that may or may not have been populated into a document. */
+export function snapshotIdOf(field: string | SnapshotDoc | null | undefined): string | undefined {
+    if (!field) return undefined;
+    return typeof field === 'string' ? field : field.id || field._id;
+}
+
+export class SyngrisiClient {
+    private readonly baseUrl: string;
+
+    private readonly apiKey?: string;
+
+    constructor(cfg: SyngrisiClientConfig) {
+        if (!cfg.url) throw new Error('SyngrisiClient: "url" is required');
+        this.baseUrl = cfg.url.endsWith('/') ? cfg.url : `${cfg.url}/`;
+        this.apiKey = cfg.apiKey;
+    }
+
+    private authHeaders(): Record<string, string> {
+        return this.apiKey ? { apikey: this.apiKey } : {};
+    }
+
+    private async requestJson<T>(path: string, init: RequestInit = {}): Promise<T> {
+        const res = await fetch(`${this.baseUrl}${path}`, {
+            ...init,
+            headers: {
+                ...this.authHeaders(),
+                ...(init.body ? { 'content-type': 'application/json' } : {}),
+                ...(init.headers as Record<string, string> | undefined),
+            },
+        });
+        const text = await res.text();
+        let body: unknown;
+        try {
+            body = text ? JSON.parse(text) : {};
+        } catch {
+            body = text;
+        }
+        if (!res.ok) {
+            const message = typeof body === 'object' ? JSON.stringify(body) : String(body);
+            throw new SyngrisiApiError(`Syngrisi API request failed (${res.status} ${res.statusText}): ${message}`, res.status);
+        }
+        return body as T;
+    }
+
+    private buildQuery(filter: Record<string, unknown>, options: ListOptions = {}): string {
+        const params = new URLSearchParams();
+        params.set('filter', JSON.stringify(filter));
+        params.set('limit', String(options.limit ?? 10));
+        if (options.sortBy) params.set('sortBy', options.sortBy);
+        if (options.populate) params.set('populate', options.populate);
+        return params.toString();
+    }
+
+    async listRuns(filter: Record<string, unknown> = {}, options: ListOptions = {}): Promise<PaginatedResult<RunDoc>> {
+        return this.requestJson<PaginatedResult<RunDoc>>(`v1/runs?${this.buildQuery(filter, { sortBy: 'createdDate:desc', ...options })}`);
+    }
+
+    async listApps(filter: Record<string, unknown> = {}, options: ListOptions = {}): Promise<PaginatedResult<AppDoc>> {
+        return this.requestJson<PaginatedResult<AppDoc>>(`v1/app?${this.buildQuery(filter, options)}`);
+    }
+
+    async listTests(filter: Record<string, unknown> = {}, options: ListOptions = {}): Promise<PaginatedResult<TestDoc>> {
+        return this.requestJson<PaginatedResult<TestDoc>>(`v1/tests?${this.buildQuery(filter, options)}`);
+    }
+
+    async listChecks(filter: Record<string, unknown> = {}, options: ListOptions = {}): Promise<PaginatedResult<CheckDoc>> {
+        return this.requestJson<PaginatedResult<CheckDoc>>(`v1/checks?${this.buildQuery(filter, options)}`);
+    }
+
+    async getCheck(checkId: string, populate = 'baselineId,actualSnapshotId,diffId'): Promise<CheckDoc | undefined> {
+        const result = await this.listChecks({ _id: checkId }, { limit: 1, populate });
+        return result.results[0];
+    }
+
+    async acceptCheck(checkId: string, baselineId: string): Promise<CheckDoc> {
+        return this.requestJson<CheckDoc>(`v1/checks/${checkId}/accept`, {
+            method: 'PUT',
+            body: JSON.stringify({ baselineId }),
+        });
+    }
+
+    /** Fetch a snapshot image by filename from the static /snapshoots route. */
+    async fetchImage(filename: string): Promise<Buffer> {
+        const res = await fetch(`${this.baseUrl}snapshoots/${filename}`, { headers: this.authHeaders() });
+        if (!res.ok) {
+            throw new SyngrisiApiError(`Failed to fetch image '${filename}' (${res.status} ${res.statusText})`, res.status);
+        }
+        const arrayBuffer = await res.arrayBuffer();
+        return Buffer.from(arrayBuffer);
+    }
+}

--- a/packages/mcp/src/cli.ts
+++ b/packages/mcp/src/cli.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SyngrisiClient } from './api';
+import { createServer } from './server';
+
+interface CliOptions {
+    url?: string;
+    apiKey?: string;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+    const opts: CliOptions = {};
+    for (let i = 0; i < argv.length; i += 1) {
+        const arg = argv[i];
+        if (arg === '--url') {
+            opts.url = argv[i + 1];
+            i += 1;
+        } else if (arg === '--api-key') {
+            opts.apiKey = argv[i + 1];
+            i += 1;
+        }
+    }
+    return opts;
+}
+
+async function main(): Promise<void> {
+    const cli = parseArgs(process.argv.slice(2));
+    const url = cli.url || process.env.SYNGRISI_URL;
+    const apiKey = cli.apiKey || process.env.SYNGRISI_API_KEY;
+
+    if (!url) {
+        // Note: never log the API key here or anywhere else.
+        // eslint-disable-next-line no-console
+        console.error('syngrisi-mcp: missing Syngrisi instance URL. Set SYNGRISI_URL or pass --url <url>.');
+        process.exit(1);
+    }
+
+    const client = new SyngrisiClient({ url, apiKey });
+    const server = createServer(client);
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+}
+
+main().catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error(`syngrisi-mcp: fatal error: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+});

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,0 +1,327 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import {
+    SyngrisiClient,
+    CheckDoc,
+    SnapshotDoc,
+    snapshotIdOf,
+} from './api';
+
+// MCP `image` content block, mirrored locally to avoid importing SDK internals.
+interface ImageBlock {
+    type: 'image';
+    data: string;
+    mimeType: string;
+}
+
+interface TextBlock {
+    type: 'text';
+    text: string;
+}
+
+type ContentBlock = TextBlock | ImageBlock;
+
+interface ToolResult {
+    [key: string]: unknown;
+    content: ContentBlock[];
+    isError?: boolean;
+}
+
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024; // 8MB guard, see plan step 2.5
+
+function text(value: string): TextBlock {
+    return { type: 'text', text: value };
+}
+
+function json(value: unknown): TextBlock {
+    return text(JSON.stringify(value, null, 2));
+}
+
+function ok(summary: string, data: unknown, extra: ContentBlock[] = []): ToolResult {
+    return { content: [text(summary), ...extra, json(data)] };
+}
+
+function errorResult(message: string): ToolResult {
+    return { content: [text(`Error: ${message}`)], isError: true };
+}
+
+function messageOf(err: unknown): string {
+    return err instanceof Error ? err.message : String(err);
+}
+
+/** Best-effort parse of a Check's `result` JSON string field (see Check.schema.ts). */
+function parseCheckResult(result: string | undefined): { misMatchPercentage?: string | number; rawMisMatchPercentage?: number } {
+    if (!result) return {};
+    try {
+        return JSON.parse(result);
+    } catch {
+        return {};
+    }
+}
+
+function snapshotFilename(field: string | SnapshotDoc | null | undefined): string | undefined {
+    if (!field || typeof field === 'string') return undefined;
+    return field.filename;
+}
+
+/** Resolve the latest run id when the caller didn't pin one down. */
+async function resolveRunId(client: SyngrisiClient, runId: string | undefined): Promise<string | undefined> {
+    if (runId) return runId;
+    const latest = await client.listRuns({}, { limit: 1 });
+    return latest.results[0]?.id;
+}
+
+async function resolveAppFilter(client: SyngrisiClient, app: string | undefined): Promise<Record<string, unknown>> {
+    if (!app) return {};
+    // `app` on a Run is an App ObjectId reference (no denormalized name), so try to
+    // resolve a human-friendly app name to its id first; fall back to using the
+    // provided value verbatim (it may already be an id).
+    try {
+        const found = await client.listApps({ name: app }, { limit: 1 });
+        if (found.results[0]?.id) return { app: found.results[0].id };
+    } catch {
+        // ignore resolution failure, fall back below
+    }
+    return { app };
+}
+
+function summarizeCheck(check: CheckDoc) {
+    const { misMatchPercentage } = parseCheckResult(check.result);
+    return {
+        id: check.id,
+        name: check.name,
+        browserName: check.browserName,
+        viewport: check.viewport,
+        os: check.os,
+        branch: check.branch,
+        misMatchPercentage: misMatchPercentage ?? null,
+        failReasons: check.failReasons ?? [],
+    };
+}
+
+export function createServer(client: SyngrisiClient): McpServer {
+    const server = new McpServer({
+        name: 'syngrisi-mcp',
+        version: '0.1.0',
+    });
+
+    server.registerTool(
+        'list_runs',
+        {
+            title: 'List Syngrisi runs',
+            description: 'List recent Syngrisi test runs, newest first. Optionally filter by app name/id.',
+            inputSchema: {
+                app: z.string().optional().describe('App name or id to filter runs by'),
+                limit: z.number().int().positive().max(100).optional().describe('Max number of runs to return (default 10)'),
+            },
+        },
+        async ({ app, limit }) => {
+            try {
+                const filter = await resolveAppFilter(client, app);
+                const result = await client.listRuns(filter, { limit: limit ?? 10 });
+                const runs = result.results.map((r) => ({
+                    id: r.id,
+                    name: r.name,
+                    app: r.app,
+                    createdDate: r.createdDate,
+                }));
+                const summary = runs.length
+                    ? `Found ${runs.length} run(s):\n${runs.map((r) => `- ${r.name} (${r.id}) created ${r.createdDate}`).join('\n')}`
+                    : 'No runs found.';
+                return ok(summary, { runs });
+            } catch (err) {
+                return errorResult(messageOf(err));
+            }
+        }
+    );
+
+    server.registerTool(
+        'get_run_status',
+        {
+            title: 'Get run status',
+            description: 'Aggregate status of a run (total/passed/failed/new tests + failed check names). Defaults to the latest run.',
+            inputSchema: {
+                runId: z.string().optional().describe('Run id; defaults to the most recent run'),
+            },
+        },
+        async ({ runId }) => {
+            try {
+                const resolvedRunId = await resolveRunId(client, runId);
+                if (!resolvedRunId) return errorResult('No runs found on this Syngrisi instance.');
+
+                const testsResult = await client.listTests({ run: resolvedRunId }, { limit: 1000 });
+                const counts = { total: testsResult.results.length, passed: 0, failed: 0, new: 0, other: 0 };
+                for (const t of testsResult.results) {
+                    if (t.status === 'Passed') counts.passed += 1;
+                    else if (t.status === 'Failed') counts.failed += 1;
+                    else if (t.status === 'New') counts.new += 1;
+                    else counts.other += 1;
+                }
+
+                const failedChecks = await client.listChecks({ run: resolvedRunId, status: ['failed'] }, { limit: 100 });
+                const failedCheckNames = failedChecks.results.map((c) => c.name);
+
+                const summary = `Run ${resolvedRunId}: ${counts.total} test(s) — `
+                    + `${counts.passed} passed, ${counts.failed} failed, ${counts.new} new`
+                    + (counts.other ? `, ${counts.other} other` : '')
+                    + (failedCheckNames.length ? `.\nFailed checks: ${failedCheckNames.join(', ')}` : '.');
+
+                return ok(summary, { runId: resolvedRunId, ...counts, failedCheckNames });
+            } catch (err) {
+                return errorResult(messageOf(err));
+            }
+        }
+    );
+
+    server.registerTool(
+        'get_failed_checks',
+        {
+            title: 'Get failed checks',
+            description: 'List failed checks for a run (name, browser, viewport, os, branch, mismatch %, fail reasons). Defaults to the latest run.',
+            inputSchema: {
+                runId: z.string().optional().describe('Run id; defaults to the most recent run'),
+                limit: z.number().int().positive().max(200).optional().describe('Max number of checks to return (default 20)'),
+            },
+        },
+        async ({ runId, limit }) => {
+            try {
+                const resolvedRunId = await resolveRunId(client, runId);
+                if (!resolvedRunId) return errorResult('No runs found on this Syngrisi instance.');
+
+                const result = await client.listChecks({ run: resolvedRunId, status: ['failed'] }, { limit: limit ?? 20 });
+                const checks = result.results.map(summarizeCheck);
+                const summary = checks.length
+                    ? `${checks.length} failed check(s) in run ${resolvedRunId}:\n${checks
+                        .map((c) => `- ${c.name} [${c.browserName}/${c.viewport}/${c.os}] ${c.misMatchPercentage ?? '?'}% (${c.id})`)
+                        .join('\n')}`
+                    : `No failed checks in run ${resolvedRunId}.`;
+                return ok(summary, { runId: resolvedRunId, checks });
+            } catch (err) {
+                return errorResult(messageOf(err));
+            }
+        }
+    );
+
+    server.registerTool(
+        'get_check',
+        {
+            title: 'Get check details',
+            description: 'Full details of a single check, including snapshot filenames and image URLs.',
+            inputSchema: {
+                checkId: z.string().describe('Check id'),
+            },
+        },
+        async ({ checkId }) => {
+            try {
+                const check = await client.getCheck(checkId);
+                if (!check) return errorResult(`Check '${checkId}' not found.`);
+
+                const images = {
+                    baseline: snapshotFilename(check.baselineId),
+                    actual: snapshotFilename(check.actualSnapshotId),
+                    diff: snapshotFilename(check.diffId),
+                };
+                const { misMatchPercentage } = parseCheckResult(check.result);
+
+                const summary = `Check '${check.name}' (${check.id}) — status: ${check.status.join(',')}, `
+                    + `mismatch: ${misMatchPercentage ?? '?'}%, browser: ${check.browserName}/${check.viewport}/${check.os}`;
+
+                return ok(summary, {
+                    id: check.id,
+                    name: check.name,
+                    status: check.status,
+                    branch: check.branch,
+                    browserName: check.browserName,
+                    browserVersion: check.browserVersion,
+                    viewport: check.viewport,
+                    os: check.os,
+                    run: check.run,
+                    test: check.test,
+                    misMatchPercentage: misMatchPercentage ?? null,
+                    failReasons: check.failReasons ?? [],
+                    markedAs: check.markedAs,
+                    images,
+                });
+            } catch (err) {
+                return errorResult(messageOf(err));
+            }
+        }
+    );
+
+    server.registerTool(
+        'get_check_images',
+        {
+            title: 'Get check images',
+            description: 'Fetch baseline/actual/diff images for a check as inline images.',
+            inputSchema: {
+                checkId: z.string().describe('Check id'),
+                which: z.enum(['baseline', 'actual', 'diff', 'all']).optional().describe('Which image(s) to return (default "all")'),
+            },
+        },
+        async ({ checkId, which }) => {
+            try {
+                const check = await client.getCheck(checkId);
+                if (!check) return errorResult(`Check '${checkId}' not found.`);
+
+                const wanted = which ?? 'all';
+                const candidates: Array<{ label: string; filename: string | undefined }> = [
+                    { label: 'baseline', filename: snapshotFilename(check.baselineId) },
+                    { label: 'actual', filename: snapshotFilename(check.actualSnapshotId) },
+                    { label: 'diff', filename: snapshotFilename(check.diffId) },
+                ].filter((c) => wanted === 'all' || wanted === c.label);
+
+                const images: ContentBlock[] = [];
+                const notes: string[] = [];
+                for (const candidate of candidates) {
+                    if (!candidate.filename) {
+                        notes.push(`${candidate.label}: no image available for this check.`);
+                        continue;
+                    }
+                    const buffer = await client.fetchImage(candidate.filename);
+                    if (buffer.length > MAX_IMAGE_BYTES) {
+                        notes.push(`${candidate.label}: image too large to return (${buffer.length} bytes > ${MAX_IMAGE_BYTES} bytes limit).`);
+                        continue;
+                    }
+                    images.push({ type: 'image', data: buffer.toString('base64'), mimeType: 'image/png' });
+                    notes.push(`${candidate.label}: ${candidate.filename} (${buffer.length} bytes)`);
+                }
+
+                const summary = `Check '${check.name}' (${check.id}) images:\n${notes.join('\n')}`;
+                return ok(summary, { checkId: check.id, requested: wanted }, images);
+            } catch (err) {
+                return errorResult(messageOf(err));
+            }
+        }
+    );
+
+    server.registerTool(
+        'accept_check',
+        {
+            title: 'Accept a check',
+            description: 'Accept a check, promoting its actual snapshot (or a given baselineId) to the new baseline.',
+            inputSchema: {
+                checkId: z.string().describe('Check id to accept'),
+                baselineId: z.string().optional().describe('Snapshot id to set as the new baseline; defaults to the check\'s own actual snapshot'),
+            },
+        },
+        async ({ checkId, baselineId }) => {
+            try {
+                const check = await client.getCheck(checkId);
+                if (!check) return errorResult(`Check '${checkId}' not found.`);
+
+                const resolvedBaselineId = baselineId ?? snapshotIdOf(check.actualSnapshotId);
+                if (!resolvedBaselineId) {
+                    return errorResult(`Cannot accept check '${checkId}': no baselineId provided and the check has no actual snapshot.`);
+                }
+
+                const accepted = await client.acceptCheck(checkId, resolvedBaselineId);
+                const summary = `Check '${accepted.name ?? checkId}' (${checkId}) accepted — new baselineId: ${resolvedBaselineId}, status: ${(accepted.status ?? []).join(',')}`;
+                return ok(summary, { checkId, baselineId: resolvedBaselineId, status: accepted.status, markedAs: accepted.markedAs });
+            } catch (err) {
+                return errorResult(messageOf(err));
+            }
+        }
+    );
+
+    return server;
+}

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Integration test for the built @syngrisi/mcp CLI: spins up a stub HTTP server that
+ * fakes the Syngrisi REST endpoints the tools rely on, spawns the compiled `dist/cli.js`
+ * as a child process, and drives it via a real MCP client over stdio.
+ *
+ * Run with: tsx --test tests/server.test.ts (see package.json "test" script).
+ * Requires `yarn build` to have produced dist/cli.js first.
+ */
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import http, { type Server } from 'node:http';
+import path from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+// A tiny (4x4 red) valid PNG, used as the stand-in for every snapshot image.
+const TINY_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAEElEQVR4nGP4z8AARwzEcQCukw/x0F8jngAAAABJRU5ErkJggg==';
+const TINY_PNG_BUFFER = Buffer.from(TINY_PNG_BASE64, 'base64');
+
+const API_KEY = 'test-api-key';
+
+interface Fixtures {
+    run: { id: string; _id: string; name: string; app: string; ident: string; createdDate: string };
+    test: { id: string; _id: string; name: string; status: string; run: string };
+    check: Record<string, unknown>;
+}
+
+const fixtures: Fixtures = {
+    run: { id: 'run1', _id: 'run1', name: 'nightly', app: 'app1', ident: 'ident-1', createdDate: '2026-01-01T00:00:00.000Z' },
+    test: { id: 'test1', _id: 'test1', name: 'homepage test', status: 'Failed', run: 'run1' },
+    check: {
+        id: 'check1',
+        _id: 'check1',
+        name: 'homepage',
+        test: 'test1',
+        suite: 'suite1',
+        app: 'app1',
+        run: 'run1',
+        branch: 'main',
+        status: ['failed'],
+        browserName: 'chrome',
+        browserVersion: '125',
+        viewport: '1024x768',
+        os: 'macOS',
+        failReasons: ['different_images'],
+        result: JSON.stringify({ misMatchPercentage: '12.34', rawMisMatchPercentage: 12.34 }),
+        baselineId: 'snap-baseline',
+        actualSnapshotId: 'snap-actual',
+        diffId: 'snap-diff',
+    },
+};
+
+const snapshots: Record<string, { id: string; _id: string; name: string; filename: string }> = {
+    'snap-baseline': { id: 'snap-baseline', _id: 'snap-baseline', name: 'baseline', filename: 'baseline.png' },
+    'snap-actual': { id: 'snap-actual', _id: 'snap-actual', name: 'actual', filename: 'actual.png' },
+    'snap-diff': { id: 'snap-diff', _id: 'snap-diff', name: 'diff', filename: 'diff.png' },
+};
+
+function populatedCheck(populate: string | null) {
+    if (!populate) return fixtures.check;
+    const fields = populate.split(',');
+    const out: Record<string, unknown> = { ...fixtures.check };
+    for (const field of fields) {
+        const value = out[field];
+        if (typeof value === 'string' && snapshots[value]) {
+            out[field] = snapshots[value];
+        }
+    }
+    return out;
+}
+
+function paginated<T>(results: T[]) {
+    return {
+        results,
+        page: 1,
+        limit: 10,
+        totalPages: 1,
+        totalResults: results.length,
+        timestamp: Date.now(),
+    };
+}
+
+let receivedAcceptHeaders: http.IncomingHttpHeaders | undefined;
+let receivedAcceptBody: unknown;
+
+function startStubServer(): Promise<Server> {
+    return new Promise((resolve) => {
+        const server = http.createServer((req, res) => {
+            const url = new URL(req.url || '/', 'http://127.0.0.1');
+            const filterRaw = url.searchParams.get('filter');
+            const filter = filterRaw ? JSON.parse(filterRaw) : {};
+            const populate = url.searchParams.get('populate');
+
+            // Negative-path fixture: force a 500 for a magic run id.
+            if (filter.run === 'boom-run' || filter._id === 'boom-run') {
+                res.writeHead(500, { 'content-type': 'application/json' });
+                res.end(JSON.stringify({ error: 'stub induced failure' }));
+                return;
+            }
+
+            if (req.method === 'GET' && url.pathname === '/v1/runs') {
+                res.writeHead(200, { 'content-type': 'application/json' });
+                res.end(JSON.stringify(paginated([fixtures.run])));
+                return;
+            }
+
+            if (req.method === 'GET' && url.pathname === '/v1/tests') {
+                res.writeHead(200, { 'content-type': 'application/json' });
+                res.end(JSON.stringify(paginated([fixtures.test])));
+                return;
+            }
+
+            if (req.method === 'GET' && url.pathname === '/v1/checks') {
+                res.writeHead(200, { 'content-type': 'application/json' });
+                res.end(JSON.stringify(paginated([populatedCheck(populate)])));
+                return;
+            }
+
+            if (req.method === 'PUT' && url.pathname === '/v1/checks/check1/accept') {
+                let body = '';
+                req.on('data', (chunk) => { body += chunk; });
+                req.on('end', () => {
+                    receivedAcceptHeaders = req.headers;
+                    receivedAcceptBody = JSON.parse(body);
+                    res.writeHead(200, { 'content-type': 'application/json' });
+                    res.end(JSON.stringify({ ...fixtures.check, status: ['passed'], markedAs: 'accepted' }));
+                });
+                return;
+            }
+
+            if (req.method === 'GET' && url.pathname.startsWith('/snapshoots/')) {
+                res.writeHead(200, { 'content-type': 'image/png' });
+                res.end(TINY_PNG_BUFFER);
+                return;
+            }
+
+            res.writeHead(404, { 'content-type': 'application/json' });
+            res.end(JSON.stringify({ error: `not found: ${url.pathname}` }));
+        });
+        server.listen(0, '127.0.0.1', () => resolve(server));
+    });
+}
+
+let stubServer: Server;
+let stubUrl: string;
+let client: Client;
+let transport: StdioClientTransport;
+
+before(async () => {
+    stubServer = await startStubServer();
+    const address = stubServer.address();
+    if (!address || typeof address === 'string') throw new Error('failed to determine stub server address');
+    stubUrl = `http://127.0.0.1:${address.port}`;
+
+    const cliPath = path.join(__dirname, '..', 'dist', 'cli.js');
+    transport = new StdioClientTransport({
+        command: process.execPath,
+        args: [cliPath],
+        env: { SYNGRISI_URL: stubUrl, SYNGRISI_API_KEY: API_KEY },
+    });
+    client = new Client({ name: 'test-client', version: '0.0.1' });
+    await client.connect(transport);
+});
+
+after(async () => {
+    await client.close();
+    await new Promise<void>((resolve) => stubServer.close(() => resolve()));
+});
+
+test('tools/list exposes exactly the six documented tools', async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name).sort();
+    assert.deepEqual(names, [
+        'accept_check',
+        'get_check',
+        'get_check_images',
+        'get_failed_checks',
+        'get_run_status',
+        'list_runs',
+    ]);
+});
+
+test('get_run_status aggregates the latest run', async () => {
+    const result = await client.callTool({ name: 'get_run_status', arguments: {} });
+    assert.equal(result.isError, undefined);
+    const content = result.content as Array<{ type: string; text?: string }>;
+    const jsonBlock = content[content.length - 1];
+    assert.equal(jsonBlock.type, 'text');
+    const data = JSON.parse(jsonBlock.text as string);
+    assert.equal(data.runId, 'run1');
+    assert.equal(data.total, 1);
+    assert.equal(data.failed, 1);
+    assert.deepEqual(data.failedCheckNames, ['homepage']);
+});
+
+test('get_failed_checks returns the mismatch percentage parsed from result JSON', async () => {
+    const result = await client.callTool({ name: 'get_failed_checks', arguments: { runId: 'run1' } });
+    assert.equal(result.isError, undefined);
+    const content = result.content as Array<{ type: string; text?: string }>;
+    const jsonBlock = content[content.length - 1];
+    const data = JSON.parse(jsonBlock.text as string);
+    assert.equal(data.checks.length, 1);
+    assert.equal(data.checks[0].id, 'check1');
+    assert.equal(data.checks[0].misMatchPercentage, '12.34');
+    assert.deepEqual(data.checks[0].failReasons, ['different_images']);
+});
+
+test('get_check_images returns an inline image content block', async () => {
+    const result = await client.callTool({ name: 'get_check_images', arguments: { checkId: 'check1', which: 'diff' } });
+    assert.equal(result.isError, undefined);
+    const content = result.content as Array<{ type: string; data?: string; mimeType?: string }>;
+    const imageBlock = content.find((c) => c.type === 'image');
+    assert.ok(imageBlock, 'expected an image content block');
+    assert.equal(imageBlock?.mimeType, 'image/png');
+    assert.equal(imageBlock?.data, TINY_PNG_BASE64);
+});
+
+test('accept_check PUTs the accept request with the apikey header and a baselineId', async () => {
+    const result = await client.callTool({ name: 'accept_check', arguments: { checkId: 'check1' } });
+    assert.equal(result.isError, undefined);
+    assert.ok(receivedAcceptHeaders, 'stub server should have received the accept request');
+    assert.equal(receivedAcceptHeaders?.apikey, API_KEY);
+    assert.equal((receivedAcceptBody as { baselineId?: string })?.baselineId, 'snap-actual');
+});
+
+test('a server error surfaces as isError: true, never a thrown exception', async () => {
+    const result = await client.callTool({ name: 'get_run_status', arguments: { runId: 'boom-run' } });
+    assert.equal(result.isError, true);
+    const content = result.content as Array<{ type: string; text?: string }>;
+    assert.ok(content[0]?.text?.startsWith('Error:'));
+});
+
+test('the API key never appears in any tool output', async () => {
+    const calls = [
+        { name: 'get_run_status', arguments: {} },
+        { name: 'get_failed_checks', arguments: { runId: 'run1' } },
+        { name: 'get_check', arguments: { checkId: 'check1' } },
+        { name: 'get_check_images', arguments: { checkId: 'check1', which: 'diff' } },
+    ];
+    for (const call of calls) {
+        const result = await client.callTool(call);
+        const content = result.content as Array<{ type: string; text?: string }>;
+        for (const block of content) {
+            if (block.type === 'text' && block.text) {
+                assert.equal(block.text.includes(API_KEY), false, `leaked API key in ${call.name} output`);
+            }
+        }
+    }
+});

--- a/packages/mcp/tests/smoke.live.ts
+++ b/packages/mcp/tests/smoke.live.ts
@@ -1,0 +1,189 @@
+/**
+ * Live smoke test for @syngrisi/mcp against a REAL, running Syngrisi instance.
+ *
+ * This is intentionally excluded from `yarn test` (see package.json "smoke:live" script) —
+ * it needs its own server + Mongo database, seeds real data via the REST API (mirroring
+ * @syngrisi/core-api's SyngrisiApi request format), and drives the built MCP CLI as a
+ * separate child process.
+ *
+ * Prerequisites (see the plan / worktree notes for exact setup):
+ *  - A Syngrisi server built and running with SYNGRISI_AUTH=false on SYNGRISI_URL
+ *    (default http://localhost:3310), pointed at its own Mongo database.
+ *  - `yarn build` already run for this package (dist/cli.js must exist).
+ *
+ * Run with: yarn smoke:live
+ */
+import { createHash, randomUUID } from 'node:crypto';
+import path from 'node:path';
+import { SyngrisiApi, ErrorObject, CheckResponse, SessionResponse } from '@syngrisi/core-api';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const SYNGRISI_URL = process.env.SYNGRISI_URL || 'http://localhost:3310/';
+
+// Two tiny (4x4) but distinct PNGs, so the second check fails against the first's baseline.
+const RED_PNG = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAEElEQVR4nGP4z8AARwzEcQCukw/x0F8jngAAAABJRU5ErkJggg==', 'base64');
+const BLUE_PNG = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAEElEQVR4nGNgYPiPhIjiAACOsw/xs6MvMwAAAABJRU5ErkJggg==', 'base64');
+
+const sha512 = (buf: Buffer) => createHash('sha512').update(buf).digest('hex');
+
+const ident = {
+    name: 'mcp-smoke-check',
+    viewport: '400x300',
+    browserName: 'chrome',
+    os: 'macOS',
+    app: 'mcp-smoke-app',
+    branch: 'main',
+};
+
+function isError(result: unknown): result is ErrorObject {
+    return !!result && typeof result === 'object' && 'error' in result && (result as ErrorObject).error === true;
+}
+
+function fail(message: string): never {
+    // eslint-disable-next-line no-console
+    console.error(`FAIL: ${message}`);
+    process.exit(1);
+}
+
+async function seed(): Promise<{ checkId: string; runId: string }> {
+    const api = new SyngrisiApi({ url: SYNGRISI_URL });
+
+    // --- Session 1: create the initial ("new") check and accept it as the baseline ---
+    const session1 = await api.startSession({
+        run: 'mcp-smoke-run-1',
+        suite: 'mcp-smoke-suite',
+        runident: randomUUID(),
+        name: ident.name,
+        viewport: ident.viewport,
+        browser: ident.browserName,
+        browserVersion: '125',
+        browserFullVersion: '125.0.0.0',
+        os: ident.os,
+        app: ident.app,
+        branch: ident.branch,
+    });
+    if (isError(session1)) fail(`startSession (1) failed: ${JSON.stringify(session1)}`);
+    const testId1 = (session1 as SessionResponse).id;
+
+    const check1 = await api.coreCheck(RED_PNG, {
+        name: ident.name,
+        viewport: ident.viewport,
+        browserName: ident.browserName,
+        os: ident.os,
+        app: ident.app,
+        branch: ident.branch,
+        testId: testId1,
+        suite: 'mcp-smoke-suite',
+        browserVersion: '125',
+        browserFullVersion: '125.0.0.0',
+        hashCode: sha512(RED_PNG),
+        skipDomData: true,
+    });
+    if (isError(check1)) fail(`coreCheck (1, baseline) failed: ${JSON.stringify(check1)}`);
+    const check1Response = check1 as CheckResponse;
+    console.log(`seed: created baseline check ${check1Response._id} with status '${check1Response.status}'`);
+
+    // A brand-new check's `baselineId` already points at its own actual snapshot
+    // (see baseline.service.ts inspectBaseline: params.baselineId = currentSnapshot.id
+    // when there's no accepted baseline yet) — accept it to create the real baseline.
+    const accepted1 = await api.acceptCheck(check1Response._id, check1Response.baselineId);
+    if (isError(accepted1)) fail(`acceptCheck (1) failed: ${JSON.stringify(accepted1)}`);
+
+    await api.stopSession(testId1);
+
+    // --- Session 2: same ident, different image -> should fail against the new baseline ---
+    const session2 = await api.startSession({
+        run: 'mcp-smoke-run-2',
+        suite: 'mcp-smoke-suite',
+        runident: randomUUID(),
+        name: ident.name,
+        viewport: ident.viewport,
+        browser: ident.browserName,
+        browserVersion: '125',
+        browserFullVersion: '125.0.0.0',
+        os: ident.os,
+        app: ident.app,
+        branch: ident.branch,
+    });
+    if (isError(session2)) fail(`startSession (2) failed: ${JSON.stringify(session2)}`);
+    const testId2 = (session2 as SessionResponse).id;
+    const runId2 = (session2 as SessionResponse).run;
+
+    const check2 = await api.coreCheck(BLUE_PNG, {
+        name: ident.name,
+        viewport: ident.viewport,
+        browserName: ident.browserName,
+        os: ident.os,
+        app: ident.app,
+        branch: ident.branch,
+        testId: testId2,
+        suite: 'mcp-smoke-suite',
+        browserVersion: '125',
+        browserFullVersion: '125.0.0.0',
+        hashCode: sha512(BLUE_PNG),
+        skipDomData: true,
+    });
+    if (isError(check2)) fail(`coreCheck (2, failing) failed: ${JSON.stringify(check2)}`);
+    const check2Response = check2 as CheckResponse;
+    console.log(`seed: created failing check ${check2Response._id} with status '${check2Response.status}'`);
+    if (!String(check2Response.status).includes('failed')) {
+        fail(`expected the second check to fail, got status '${check2Response.status}'`);
+    }
+
+    await api.stopSession(testId2);
+
+    return { checkId: check2Response._id, runId: runId2 };
+}
+
+async function main(): Promise<void> {
+    const { checkId, runId } = await seed();
+
+    const cliPath = path.join(__dirname, '..', 'dist', 'cli.js');
+    const transport = new StdioClientTransport({
+        command: process.execPath,
+        args: [cliPath],
+        env: { SYNGRISI_URL },
+    });
+    const client = new Client({ name: 'smoke-live-client', version: '0.0.1' });
+    await client.connect(transport);
+
+    let passCount = 0;
+    const assert = (condition: boolean, message: string) => {
+        if (condition) {
+            console.log(`PASS: ${message}`);
+            passCount += 1;
+        } else {
+            fail(message);
+        }
+    };
+
+    // 1. get_run_status: 1 failed check on the freshly seeded run
+    const statusResult = await client.callTool({ name: 'get_run_status', arguments: { runId } });
+    assert(statusResult.isError !== true, 'get_run_status did not error');
+    const statusJson = JSON.parse((statusResult.content as Array<{ text?: string }>).at(-1)?.text || '{}');
+    assert(statusJson.failed === 1, `get_run_status reports 1 failed test (got ${statusJson.failed})`);
+
+    // 2. get_check_images: diff image is returned as an inline image block
+    const imagesResult = await client.callTool({ name: 'get_check_images', arguments: { checkId, which: 'diff' } });
+    assert(imagesResult.isError !== true, 'get_check_images did not error');
+    const hasImage = (imagesResult.content as Array<{ type: string }>).some((c) => c.type === 'image');
+    assert(hasImage, 'get_check_images returned an inline diff image');
+
+    // 3. accept_check: the check becomes accepted, verified via a direct GET
+    const acceptResult = await client.callTool({ name: 'accept_check', arguments: { checkId } });
+    assert(acceptResult.isError !== true, 'accept_check did not error');
+
+    const verifyRes = await fetch(`${SYNGRISI_URL}v1/checks?filter=${encodeURIComponent(JSON.stringify({ _id: checkId }))}&limit=1`);
+    const verifyJson = await verifyRes.json() as { results: Array<{ markedAs?: string }> };
+    assert(verifyJson.results[0]?.markedAs === 'accepted', `check ${checkId} is marked accepted after accept_check`);
+
+    await client.close();
+
+    console.log(`\n${passCount}/3 assertions passed. PASS`);
+}
+
+main().catch((err) => {
+    console.error(`FAIL: unexpected error: ${err instanceof Error ? err.stack : String(err)}`);
+    process.exit(1);
+});

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "incremental": true,
+    "target": "ES2022",
+    "module": "commonjs",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "tests/**",
+    "dist",
+    "node_modules",
+    "coverage"
+  ]
+}

--- a/packages/playwright-sdk/src/PlaywrightDriver.ts
+++ b/packages/playwright-sdk/src/PlaywrightDriver.ts
@@ -119,7 +119,8 @@ export class PlaywrightDriver {
                 runident: params.runident,
                 suite: params.suite,
                 tags: params.tags,
-                browserFullVersion: params.browserFullVersion || getBrowserFullVersion(this.browser.version())
+                browserFullVersion: params.browserFullVersion || getBrowserFullVersion(this.browser.version()),
+                commit: params.commit
             }
 
             // @ts-ignore

--- a/packages/playwright-sdk/src/schemas/SessionParams.schema.ts
+++ b/packages/playwright-sdk/src/schemas/SessionParams.schema.ts
@@ -12,7 +12,8 @@ export const SessionParamsSchema = z.object({
     browserName: z.string().min(1).optional(),
     browserVersion: z.string().min(1).optional(),
     browserFullVersion: z.string().min(1).optional(),
-    tags: z.array(z.string()).optional()
+    tags: z.array(z.string()).optional(),
+    commit: z.string().regex(/^[0-9a-fA-F]{7,40}$/).optional(), // Git commit SHA, used to report a commit status back to GitHub
 }).catchall(z.union([z.string(), z.array(z.string()), z.undefined()]))
 
 export type SessionParams = z.infer<typeof SessionParamsSchema>;

--- a/packages/playwright-sdk/types/index.d.ts
+++ b/packages/playwright-sdk/types/index.d.ts
@@ -31,6 +31,8 @@ export interface SessionParams {
     browserVersion?: string;
     browserFullVersion?: string;
     tags?: string[];
+    /** Git commit SHA the run belongs to, used to report a commit status back to GitHub */
+    commit?: string;
 
     [key: string]: string | string[] | undefined;
 }
@@ -48,6 +50,7 @@ export interface ApiSessionParams {
     browserVersion: string;
     os: string;
     app: string;
+    commit?: string;
 
     [key: string]: string | string[] | undefined;
 }
@@ -138,6 +141,7 @@ interface TestParams {
     tags?: string[];
     browserFullVersion?: string;
     testId?: string | undefined;
+    commit?: string;
 }
 
 interface Params {

--- a/packages/syngrisi/docker-compose.yml
+++ b/packages/syngrisi/docker-compose.yml
@@ -36,6 +36,11 @@ services:
       SYNGRISI_HTTP_LOG: "${SYNGRISI_HTTP_LOG:-false}"
       SYNGRISI_DISABLE_DEV_CORS: "true"
       SYNGRISI_RCA: "${SYNGRISI_RCA}"
+      # "Private AI" (docker compose --profile ai): point AI Triage at the bundled Ollama
+      # service instead of a cloud API. No-ops when unset (both default empty/false), so
+      # plain `docker compose up` (no profile) is unaffected. See docs/AI_FEATURES.md.
+      SYNGRISI_AI_TRIAGE_ENABLED: "${SYNGRISI_AI_TRIAGE_ENABLED:-false}"
+      SYNGRISI_AI_TRIAGE_PROVIDER_JSON: "${SYNGRISI_AI_TRIAGE_PROVIDER_JSON:-}"
 
   syngrisi-db:
     cap_add:
@@ -63,3 +68,45 @@ services:
       timeout: 15s
       retries: 3000
       start_period: 40s
+
+  # "Private AI" — bundled Ollama for AI Triage, only started via `docker compose --profile ai up`.
+  # Zero API keys, zero screenshot egress: triage runs entirely against this local vision model.
+  ollama:
+    image: ollama/ollama:latest
+    container_name: syngrisi-ollama
+    profiles: ["ai"]
+    restart: unless-stopped
+    ports:
+      - "${OLLAMA_PORT:-11434}:11434"
+    volumes:
+      - "${SYNGRISI_DOCKER_OLLAMA_DATA_PATH:-ollama_data}:/root/.ollama"
+    logging:
+      driver: 'json-file'
+      options:
+        max-size: '100m'
+        max-file: '10'
+    healthcheck:
+      # The API being up is enough for "healthy" — pulling the (multi-GB) model happens in the
+      # separate `ollama-pull` service so the healthcheck never blocks on a slow first-time download.
+      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 30
+      start_period: 20s
+
+  # One-shot: pulls the vision model into the `ollama` service's volume, then exits.
+  # Runs on every `--profile ai up` but `ollama pull` is a no-op once the model is already cached.
+  ollama-pull:
+    image: ollama/ollama:latest
+    container_name: syngrisi-ollama-pull
+    profiles: ["ai"]
+    depends_on:
+      ollama:
+        condition: service_healthy
+    environment:
+      OLLAMA_HOST: "ollama:11434"
+    entrypoint: ["sh", "-c", "ollama pull \"${OLLAMA_MODEL:-gemma4:12b}\""]
+    restart: "no"
+
+volumes:
+  ollama_data: {}

--- a/packages/syngrisi/docs/AI_FEATURES.md
+++ b/packages/syngrisi/docs/AI_FEATURES.md
@@ -70,3 +70,69 @@ Syngrisi provides a set of features designed to facilitate integration with AI a
 
 All AI endpoints require authentication via API Key or Session cookie.
 Header: `apikey: <your-api-key>`
+
+## Private AI with Ollama (docker profile)
+
+AI Triage can run fully on your own hardware — no API keys, no screenshot egress. The
+`ai` docker compose profile bundles an [Ollama](https://ollama.com) service with a vision
+model and wires the Syngrisi app to it via environment variables.
+
+### Quick start
+
+```bash
+cd packages/syngrisi
+
+SYNGRISI_AI_TRIAGE_ENABLED=true \
+SYNGRISI_AI_TRIAGE_PROVIDER_JSON='{"type":"openai","baseUrl":"http://ollama:11434/v1","model":"gemma4:12b"}' \
+docker compose --profile ai up -d
+```
+
+This starts the regular `syngrisi-app` + `syngrisi-db` services plus:
+
+- **`ollama`** — the Ollama server (official `ollama/ollama` image). Models are stored in
+  the named volume `ollama_data`, so they survive restarts. The healthcheck only verifies
+  the API is up — it never waits for a model download.
+- **`ollama-pull`** — a one-shot helper that pulls the vision model (`OLLAMA_MODEL`,
+  default `gemma4:12b`, several GB on first run) into that volume and exits. Re-runs are
+  instant no-ops once the model is cached. You can also pull manually instead:
+  `docker exec syngrisi-ollama ollama pull gemma4:12b`.
+
+Then enable triage per project (Admin → AI → Projects settings, or
+`PATCH /v1/app/:id/triage-policy` with `{"triageEnabled": true}`) — failed checks get
+classified by the local model.
+
+### Environment variables
+
+| Variable | Default | Description |
+| :--- | :--- | :--- |
+| `OLLAMA_MODEL` | `gemma4:12b` | Vision model pulled by `ollama-pull` (any multimodal Ollama model) |
+| `OLLAMA_PORT` | `11434` | Host port the Ollama API is published on |
+| `SYNGRISI_DOCKER_OLLAMA_DATA_PATH` | `ollama_data` (named volume) | Where model files are stored |
+| `SYNGRISI_AI_TRIAGE_ENABLED` | `false` | Global AI Triage on/off (env wins over the admin UI) |
+| `SYNGRISI_AI_TRIAGE_PROVIDER_JSON` | — | Provider config as a JSON string; applied to the `ai_triage_provider` setting on every startup (env wins over the admin UI). Fields: `type`, `baseUrl`, `apiKey`, `model`, and optional `maxTokens` / `temperature` / `timeoutMs` |
+
+Inside the compose network the app reaches Ollama at `http://ollama:11434/v1`
+(OpenAI-compatible endpoint; `apiKey` may be omitted — Ollama ignores it).
+
+`SYNGRISI_AI_TRIAGE_PROVIDER_JSON` also works outside docker — point any Syngrisi server
+at any OpenAI-compatible endpoint, e.g. a host-local Ollama:
+
+```bash
+SYNGRISI_AI_TRIAGE_PROVIDER_JSON='{"type":"openai","baseUrl":"http://127.0.0.1:11434/v1","model":"gemma4:12b"}'
+```
+
+### Lifecycle
+
+```bash
+docker compose --profile ai up -d     # start everything, pull the model in the background
+docker compose --profile ai down      # stop; the model volume is KEPT
+docker compose --profile ai down -v   # stop and delete the model volume (re-download on next up)
+```
+
+Notes:
+
+- Local VLM inference is CPU/GPU heavy; a single classification can take tens of seconds
+  to minutes depending on hardware. See [AI_TRIAGE.md](../AI_TRIAGE.md) for model
+  recommendations and tuning.
+- Plain `docker compose up` (without `--profile ai`) is unaffected — the Ollama services
+  only exist inside the `ai` profile.

--- a/packages/syngrisi/docs/BRANCH_BASELINES.md
+++ b/packages/syngrisi/docs/BRANCH_BASELINES.md
@@ -1,0 +1,48 @@
+# Branch baselines: main-branch fallback
+
+A baseline's identity includes `branch` (alongside `name`, `viewport`, `browserName`, `os`, `app`).
+Without a fallback, a brand-new feature branch starts with **zero accepted baselines**, so the whole
+suite lands as `new` / `not_accepted` on its first run — even though visually identical baselines
+were already approved on `main`. This feature adds a **read-time fallback**: if no accepted baseline
+exists for a check's own branch, and the project has a configured main branch, the check is compared
+against the main branch's accepted baseline instead.
+
+## How it works
+
+- Each project (App) may have a `mainBranch` setting (empty by default = feature disabled,
+  preserving today's behavior for every existing project).
+- When a check is created and no accepted baseline exists for its own branch, the server looks up
+  the project's `mainBranch` and retries the accepted-baseline lookup with that branch instead.
+- If a fallback baseline is found, the check is **compared** against it — it passes if identical,
+  fails with a real diff if not. It is not marked `new` / `not_accepted`.
+- If no `mainBranch` is configured, or the main branch itself has no accepted baseline either, the
+  check falls back to the original behavior (`new` on first check, `not_accepted` if check history
+  exists without a valid baseline).
+
+## Accepting stays branch-scoped
+
+Accepting a check always creates/updates the baseline for the check's **own** branch — the fallback
+only affects which baseline a check is compared against at read time. This means:
+
+- Accepting a check on `feature-x` does not touch `main`'s baseline.
+- Once a branch has its own accepted baseline, that baseline is used going forward (the exact-branch
+  lookup always takes priority over the fallback).
+
+## Configuring the main branch
+
+Set it per project in **Admin → AI → Projects settings** (the "Branch baselines" section) via the
+"Main branch" field, or via the API:
+
+```bash
+curl -X PATCH "$SYNGRISI_URL/v1/app/<appId>/triage-policy" \
+  -H "Content-Type: application/json" \
+  -d '{"mainBranch": "main"}'
+```
+
+Leave it empty to disable the fallback for a project.
+
+## What is out of scope (deferred)
+
+- Auto-promotion of feature-branch baselines to `main` on merge.
+- A per-check UI badge indicating "compared against main's baseline".
+- Multi-level fallback chains (only one fallback branch is supported).

--- a/packages/syngrisi/docs/TIME_MACHINE.md
+++ b/packages/syngrisi/docs/TIME_MACHINE.md
@@ -1,0 +1,105 @@
+# Baseline "Time Machine"
+
+## Overview
+
+Every accepted baseline is already stored (`Baseline` documents + snapshot image files), so the
+full visual history of a check exists in the database - it's just never been visible in one place.
+The "time machine" lets you pick a check and scrub through its accepted baselines over time
+(a history slider), with an optional AI-generated one-line summary of what changed between two
+consecutive baselines.
+
+## How It Works
+
+```
+Baseline docs (accepted, sorted by createdDate) ──► GET  /v1/baselines/history
+                                                        │
+                                                        ▼
+                                              ordered timeline (id, date, image)
+                                                        │
+                                                        ▼
+                                     UI: History modal + Mantine Slider (prev/next)
+                                                        │
+                                     POST /v1/baselines/history-summary (lazy, on step)
+                                                        │
+                                                        ▼
+                                   AI triage provider `classify()` reused for a
+                                   free-text "reason" describing the visual change
+                                   (cached on the newer Baseline's `historySummary` field)
+```
+
+- History is just `Baseline.find({...ident, markedAs: 'accepted'}).sort({createdDate: 1})` -
+  no new storage, no schedulers.
+- The summary reuses the existing AI triage provider abstraction
+  (`services/triage/factory.ts` `createProvider(cfg)` + `services/triage/config.ts`
+  `getProviderConfig()`) - the same `classify()` call used for triage verdicts, given a custom
+  prompt asking for a one-sentence description instead of a verdict. The model's `reason` field is
+  used as the summary text; `verdict`/`confidence` are ignored.
+- When no AI provider is configured, the summary endpoint returns `{summary: null, reason: 'no
+  provider configured'}` and the UI just shows the slider without a summary line.
+- Each baseline pair is summarized once: the result is cached on the *newer* baseline's
+  `historySummary` field (`{fromBaselineId, text}`), and repeat requests for the same pair return
+  `cached: true` instead of calling the provider again.
+
+## API
+
+### `GET /v1/baselines/history?filter=<ident-json>`
+
+Returns the ordered accepted-baseline timeline for one check ident.
+
+```json
+{
+  "filter": "{\"name\":\"Login page\",\"app\":\"6651dd45b9c3e1e0b8c1ce26\",\"branch\":\"master\",\"browserName\":\"chrome\",\"viewport\":\"1366x768\",\"os\":\"macOS\"}"
+}
+```
+
+Response - array of items, oldest first:
+
+```json
+[
+  {
+    "id": "6651ec20917e9ce26f7c0849",
+    "createdDate": "2024-05-26T10:49:19.896Z",
+    "markedByUsername": "Guest",
+    "filename": "6651ec20917e9ce26f7c0849.png",
+    "imageUrl": "/snapshoots/6651ec20917e9ce26f7c0849.png"
+  }
+]
+```
+
+Note: unlike the SDK-facing ident (`client.route.ts`, where `app` is the app *name*), this
+endpoint's `app` is the App document's ObjectId - matching how the UI already reads baselines
+(`GET /v1/baselines`).
+
+### `POST /v1/baselines/history-summary`
+
+```json
+{ "fromBaselineId": "<older baseline id>", "toBaselineId": "<newer baseline id>" }
+```
+
+Response:
+
+```json
+{ "summary": "header redesigned with a new logo", "cached": false }
+```
+
+or, when no provider is configured:
+
+```json
+{ "summary": null, "reason": "no provider configured" }
+```
+
+A provider is considered "configured" when the stored `ai_triage_provider` setting has an explicit
+`apiKey`/`baseUrl` (or is the `fake` test provider) - the default seeded setting
+(`{type: 'openai', apiKey: '', baseUrl: ''}`) counts as unconfigured, so the feature degrades to a
+plain slider by default.
+
+## UI
+
+On the Baselines table (`/baselines`), each row has a "History" action (clock icon) that opens a
+modal with the current image, a Mantine `Slider` over the timeline (labelled by date), prev/next
+buttons, and - once you step to a baseline that has a predecessor - a lazily-fetched one-line AI
+summary (hidden when `summary` is `null`).
+
+## Scope
+
+Out of scope: comparison engine changes, schedulers, video/GIF export.

--- a/packages/syngrisi/docs/WEBHOOKS.md
+++ b/packages/syngrisi/docs/WEBHOOKS.md
@@ -1,0 +1,103 @@
+# Webhooks
+
+Syngrisi can notify external systems (Slack, CI, ChatOps, ...) about lifecycle
+events by POSTing a JSON payload to one or more registered webhook URLs.
+
+This document covers the management API and the delivery contract. Webhooks
+are managed via the REST API described below, or via the admin UI at
+`/admin/webhooks`.
+
+## Events
+
+| Event | Fired when | Payload |
+|---|---|---|
+| `check.created` | A new visual check is created | The created check document |
+| `check.updated` | A check is updated (accepted, rejected, recompared, ...) | The updated check document |
+| `test.finished` | A test session ends (`endSession`) | The updated test document (`status`, `blinking`, `app`, `run`, `branch`, ...) |
+
+`test.finished` fires once per test session (when the SDK/client ends the
+session), not once per check.
+
+## Delivery
+
+For every fired event, Syngrisi looks up all enabled webhooks subscribed to
+that event (`Webhook.find({ events: event, enabled: { $ne: false } })`) and
+sends, for each one:
+
+```
+POST <webhook.url>
+Content-Type: application/json
+X-Syngrisi-Event: <event>
+X-Syngrisi-Secret: <webhook.secret or empty string>
+
+{
+  "event": "<event>",
+  "payload": { ... },
+  "timestamp": "2024-06-13T18:33:38.617Z"
+}
+```
+
+Delivery is fire-and-forget with a single attempt and a 5s timeout. Delivery
+failures are logged, not retried, and never affect the triggering request
+(check/test API calls always succeed regardless of webhook delivery outcome).
+
+Use the `X-Syngrisi-Secret` header to verify the request came from your
+Syngrisi instance (simple shared-secret check; there is no HMAC signature).
+
+## Management API
+
+All endpoints require `ensureLoggedIn()` (a logged-in session or API key).
+
+`secret` is **write-only**: it can be set on create/update but is never
+returned by any endpoint (GET, POST, PATCH, DELETE responses all strip it).
+
+### List webhooks
+
+```
+GET /v1/webhooks
+```
+
+Paginated (`limit`, `page`, `sortBy`, `filter` query params, same convention
+as other list endpoints, e.g. `/v1/suites`).
+
+### Create a webhook
+
+```
+POST /v1/webhooks
+Content-Type: application/json
+
+{
+  "url": "https://example.com/hooks/syngrisi",
+  "events": ["check.created", "check.updated", "test.finished"],
+  "secret": "optional-shared-secret",
+  "enabled": true
+}
+```
+
+`events` defaults to `["check.updated", "check.created"]` if omitted.
+`enabled` defaults to `true`.
+
+### Update a webhook
+
+```
+PATCH /v1/webhooks/{id}
+Content-Type: application/json
+
+{ "enabled": false }
+```
+
+Any subset of `url`, `events`, `secret`, `enabled` may be sent.
+
+### Delete a webhook
+
+```
+DELETE /v1/webhooks/{id}
+```
+
+## Example: cURL
+
+```bash
+curl -X POST http://localhost:3000/v1/webhooks \
+  -H 'Content-Type: application/json' \
+  -d '{"url":"https://example.com/hooks/syngrisi","events":["test.finished"]}'
+```

--- a/packages/syngrisi/docs/environment_variables.md
+++ b/packages/syngrisi/docs/environment_variables.md
@@ -59,6 +59,22 @@
     - Default Value: `false`
     - Note: To actually send DOM snapshots for RCA, set `SYNGRISI_DISABLE_DOM_DATA=false` (default is to skip DOM data).
 
+15. `SYNGRISI_GITHUB_TOKEN`
+    - Description: Personal/fine-grained GitHub access token with `repo:status` scope, used to report a run's outcome back to GitHub as a commit status. Never logged or persisted to the database.
+    - Default Value: `-` (dormant, zero requests, until set together with `SYNGRISI_GITHUB_REPO` and a session's `commit` param)
+
+16. `SYNGRISI_GITHUB_REPO`
+    - Description: The `<owner>/<name>` GitHub repository to post commit statuses to.
+    - Default Value: `-`
+
+17. `SYNGRISI_PUBLIC_URL`
+    - Description: Public base URL of this Syngrisi instance, used to build the `target_url` deep link on the GitHub commit status (points at the run's grid).
+    - Default Value: `-`
+
+18. `SYNGRISI_GITHUB_API_URL`
+    - Description: Override for the GitHub API base URL (e.g. for GitHub Enterprise, or to point at a stub in tests).
+    - Default Value: `https://api.github.com`
+
 ### Docker Mode
 
 1. `SYNGRISI_DOCKER_IMAGES_PATH`

--- a/packages/syngrisi/e2e/features/CHECKS_HANDLING/branch_baseline_fallback.feature
+++ b/packages/syngrisi/e2e/features/CHECKS_HANDLING/branch_baseline_fallback.feature
@@ -1,0 +1,124 @@
+@fast-server
+Feature: Branch baseline fallback to the project's main branch
+    When no accepted baseline exists for a check's own branch, and the project has a configured
+    `mainBranch`, the check is compared against the main branch's accepted baseline instead of
+    landing as `new`/`not_accepted`. Accepting stays branch-scoped: accepting a check still creates
+    a baseline for the check's own branch (untouched by this feature).
+
+    Background:
+        Given I clear database
+
+    @smoke
+    Scenario: A feature branch check with the same image as main's accepted baseline passes
+        Given I create "1" tests with:
+            """
+            testName: MainBranchTest
+            project: BranchFallbackAppSame
+            branch: main
+            checks:
+              - checkName: FallbackCheck
+                filePath: files/A.png
+            """
+        When I accept via http the 1st check with name "FallbackCheck"
+        And the project "BranchFallbackAppSame" has main branch "main"
+
+        Given I create "1" tests with:
+            """
+            testName: FeatureBranchTest
+            project: BranchFallbackAppSame
+            branch: feature-x
+            checks:
+              - checkName: FallbackCheck
+                filePath: files/A.png
+            """
+
+        Then I expect via http 1st check filtered as "name=FallbackCheck" matched:
+            """
+            name: FallbackCheck
+            branch: feature-x
+            status: [passed]
+            """
+
+    Scenario: A feature branch check with a different image than main's accepted baseline fails (compared, not "new")
+        Given I create "1" tests with:
+            """
+            testName: MainBranchTest
+            project: BranchFallbackAppDiff
+            branch: main
+            checks:
+              - checkName: FallbackCheck
+                filePath: files/A.png
+            """
+        When I accept via http the 1st check with name "FallbackCheck"
+        And the project "BranchFallbackAppDiff" has main branch "main"
+
+        Given I create "1" tests with:
+            """
+            testName: FeatureBranchTest
+            project: BranchFallbackAppDiff
+            branch: feature-x
+            checks:
+              - checkName: FallbackCheck
+                filePath: files/B.png
+            """
+
+        Then I expect via http 1st check filtered as "name=FallbackCheck" matched:
+            """
+            name: FallbackCheck
+            branch: feature-x
+            status: [failed]
+            failReasons: [different_images]
+            """
+
+    Scenario: Regression control - without a configured main branch, a feature branch check is still "new"
+        Given I create "1" tests with:
+            """
+            testName: MainBranchTest
+            project: BranchFallbackAppControl
+            branch: main
+            checks:
+              - checkName: FallbackCheck
+                filePath: files/A.png
+            """
+        When I accept via http the 1st check with name "FallbackCheck"
+        # mainBranch is intentionally left unset for this project
+
+        Given I create "1" tests with:
+            """
+            testName: FeatureBranchTest
+            project: BranchFallbackAppControl
+            branch: feature-x
+            checks:
+              - checkName: FallbackCheck
+                filePath: files/A.png
+            """
+
+        Then I expect via http 1st check filtered as "name=FallbackCheck" matched:
+            """
+            name: FallbackCheck
+            branch: feature-x
+            status: [new]
+            """
+
+    Scenario: Setting the project's main branch via the API persists it
+        Given I create "1" tests with:
+            """
+            testName: MainBranchTest
+            project: BranchFallbackAppSetting
+            branch: main
+            checks:
+              - checkName: FallbackCheck
+                filePath: files/A.png
+            """
+        When I accept via http the 1st check with name "FallbackCheck"
+
+        Then I expect via http 1st check filtered as "name=FallbackCheck" matched:
+            """
+            name: FallbackCheck
+            branch: main
+            markedAs: accepted
+            status: [new]
+            """
+
+        Given the project "BranchFallbackAppSetting" has main branch "main"
+        Then the project "BranchFallbackAppSetting" main branch is "main"

--- a/packages/syngrisi/e2e/features/INTEGRATION/baseline_history.feature
+++ b/packages/syngrisi/e2e/features/INTEGRATION/baseline_history.feature
@@ -1,0 +1,86 @@
+@fast-server
+Feature: Baseline "time machine" - history slider over a check's accepted baselines
+  A check's accepted baselines form a visual timeline (Baseline docs, ordered by createdDate).
+  GET /v1/baselines/history returns that ordered timeline for one check ident, and
+  POST /v1/baselines/history-summary optionally describes the change between two baselines via
+  the configured AI triage provider (degrading to a plain slider when no provider is configured).
+  API-driven only - no UI assertions here (see docs/TIME_MACHINE.md for the UI entry point).
+
+  Scenario: History returns the ordered accepted-baseline timeline for one check ident
+    Given I create "1" tests with:
+      """
+      testName: HistoryTest
+      project: HistoryApp
+      checks:
+        - checkName: HistoryCheck
+          filePath: files/A.png
+      """
+    When I accept via http the 1st check with name "HistoryCheck"
+    Given I create "1" tests with:
+      """
+      testName: HistoryTest
+      project: HistoryApp
+      checks:
+        - checkName: HistoryCheck
+          filePath: files/B.png
+      """
+    When I accept via http the 1st check with name "HistoryCheck"
+    When I fetch via http baseline history for check "HistoryCheck"
+    Then the baseline history should have 2 items ordered by date
+
+  Scenario: Summary endpoint degrades to slider-only without a configured provider
+    Given I create "1" tests with:
+      """
+      testName: SummaryTest
+      project: SummaryApp
+      checks:
+        - checkName: SummaryCheck
+          filePath: files/A.png
+      """
+    When I accept via http the 1st check with name "SummaryCheck"
+    Given I create "1" tests with:
+      """
+      testName: SummaryTest
+      project: SummaryApp
+      checks:
+        - checkName: SummaryCheck
+          filePath: files/B.png
+      """
+    When I accept via http the 1st check with name "SummaryCheck"
+    When I fetch via http baseline history for check "SummaryCheck"
+    Then the baseline history should have 2 items ordered by date
+    When I request the baseline history summary for the last two history items
+    Then the baseline history summary should be null with reason "no provider configured"
+
+  Scenario: Summary endpoint returns a non-empty AI summary and caches it
+    Given I create "1" tests with:
+      """
+      testName: SummaryCacheTest
+      project: SummaryCacheApp
+      checks:
+        - checkName: SummaryCacheCheck
+          filePath: files/A.png
+      """
+    When I accept via http the 1st check with name "SummaryCacheCheck"
+    Given I create "1" tests with:
+      """
+      testName: SummaryCacheTest
+      project: SummaryCacheApp
+      checks:
+        - checkName: SummaryCacheCheck
+          filePath: files/B.png
+      """
+    When I accept via http the 1st check with name "SummaryCacheCheck"
+    When I update via http setting "ai_triage_provider" with params:
+      """
+      value:
+        type: fake
+        fakeReason: header redesigned with a new logo
+      enabled: true
+      """
+    When I fetch via http baseline history for check "SummaryCacheCheck"
+    Then the baseline history should have 2 items ordered by date
+    When I request the baseline history summary for the last two history items
+    Then the baseline history summary should be a non-empty string
+    When I request the baseline history summary for the last two history items
+    Then the baseline history summary should be cached

--- a/packages/syngrisi/e2e/features/INTEGRATION/github_status.feature
+++ b/packages/syngrisi/e2e/features/INTEGRATION/github_status.feature
@@ -1,0 +1,35 @@
+@fast-server @integration
+Feature: GitHub commit-status integration
+
+    # Covers reporting a run's outcome back to GitHub as a commit status (POST
+    # /repos/{owner}/{repo}/statuses/{sha}), fired fire-and-forget from endSession.
+    # See docs/environment_variables.md (SYNGRISI_GITHUB_TOKEN/_REPO/_PUBLIC_URL/_API_URL).
+
+    Background:
+        When I set env variables:
+            """
+            SYNGRISI_AUTH: "false"
+            SYNGRISI_TEST_MODE: "true"
+            SYNGRISI_GITHUB_TOKEN: "test-gh-token"
+            SYNGRISI_GITHUB_REPO: "acme/widgets"
+            SYNGRISI_PUBLIC_URL: "http://localhost:8080"
+            """
+        Given I start Server
+        And I clear database
+        And I start a GitHub status stub server
+
+    Scenario: A finished session with a commit reports a success status to GitHub
+        Given I create a "wdio" Syngrisi driver
+        When I start an SDK test session for app "GithubStatusApp" with commit "a1b2c3d"
+        Then the SDK check "Home" with image "files/A.png" has status "new"
+        When I accept the last SDK check
+        Then the SDK check "Home" with image "files/A.png" has status "passed"
+        When I stop the SDK test session
+        Then the GitHub status stub should have received a status POST for commit "a1b2c3d" with state "success"
+
+    Scenario: A finished session without a commit never calls GitHub
+        Given I create a "wdio" Syngrisi driver
+        When I start an SDK test session for app "GithubStatusApp"
+        Then the SDK check "NoCommit" with image "files/A.png" has status "new"
+        When I stop the SDK test session
+        Then the GitHub status stub should have received no requests

--- a/packages/syngrisi/e2e/features/INTEGRATION/webhooks_crud.feature
+++ b/packages/syngrisi/e2e/features/INTEGRATION/webhooks_crud.feature
@@ -1,0 +1,39 @@
+@fast-server @integration
+Feature: Webhooks management API
+
+    # Covers the CRUD surface added on top of the pre-existing webhook delivery
+    # engine: POST/GET/PATCH/DELETE /v1/webhooks. See docs/WEBHOOKS.md.
+
+    Background:
+        When I set env variables:
+            """
+            SYNGRISI_AUTH: "false"
+            SYNGRISI_TEST_MODE: "true"
+            """
+        Given I start Server
+        And I clear database
+
+    Scenario: Create, list, update and delete a webhook via the API
+        When I create via http "webhook" with params:
+            """
+            url: "http://localhost:9999/webhooks-crud-test"
+            events:
+                - "test.finished"
+            """
+        Then I expect via http that "webhook" filtered as "url=webhooks-crud-test" exist exactly "1" times
+        And I expect via http "webhook" filtered as "url=webhooks-crud-test" to match:
+            """
+            enabled: true
+            events:
+                - "test.finished"
+            """
+        When I update via http "webhook" filtered as "url=webhooks-crud-test" with params:
+            """
+            enabled: false
+            """
+        Then I expect via http "webhook" filtered as "url=webhooks-crud-test" to match:
+            """
+            enabled: false
+            """
+        When I delete via http "webhook" filtered as "url=webhooks-crud-test"
+        Then I expect via http that "webhook" filtered as "url=webhooks-crud-test" exist exactly "0" times

--- a/packages/syngrisi/e2e/steps/domain/branch-baseline.steps.ts
+++ b/packages/syngrisi/e2e/steps/domain/branch-baseline.steps.ts
@@ -1,0 +1,38 @@
+import { Given, Then } from '@fixtures';
+import type { AppServerFixture } from '@fixtures';
+import type { TestStore } from '@fixtures';
+import { requestWithSession } from '@utils/http-client';
+import { expect } from '@playwright/test';
+
+async function getAppByName(appServer: AppServerFixture, testData: TestStore, project: string): Promise<any> {
+    const listUri = `${appServer.baseURL}/v1/app?limit=0&filter={"name":"${project}"}`;
+    const listResp = await requestWithSession(listUri, testData, appServer);
+    const app = (listResp.json.results || [])[0];
+    expect(app, `project "${project}" not found`).toBeTruthy();
+    return app;
+}
+
+// Set the project's read-time baseline fallback branch via the app API
+// (PATCH /v1/app/:id/triage-policy, which also accepts the mainBranch field — see
+// AppTriagePolicy.schema.ts / app.controller.ts).
+Given(
+    'the project {string} has main branch {string}',
+    async ({ appServer, testData }: { appServer: AppServerFixture; testData: TestStore }, project: string, mainBranch: string) => {
+        const app = await getAppByName(appServer, testData, project);
+        const id = app._id || app.id;
+        const patchUri = `${appServer.baseURL}/v1/app/${id}/triage-policy`;
+        const resp = await requestWithSession(patchUri, testData, appServer, {
+            method: 'PATCH',
+            json: { mainBranch },
+        });
+        expect(resp.raw?.statusCode).toBe(200);
+    },
+);
+
+Then(
+    'the project {string} main branch is {string}',
+    async ({ appServer, testData }: { appServer: AppServerFixture; testData: TestStore }, project: string, mainBranch: string) => {
+        const app = await getAppByName(appServer, testData, project);
+        expect(app.mainBranch).toBe(mainBranch);
+    },
+);

--- a/packages/syngrisi/e2e/steps/domain/github-status.steps.ts
+++ b/packages/syngrisi/e2e/steps/domain/github-status.steps.ts
@@ -1,0 +1,113 @@
+import { Given, When, Then } from '@fixtures';
+import type { AppServerFixture, TestStore } from '@fixtures';
+import { createLogger } from '@lib/logger';
+import { expect } from '@playwright/test';
+import * as http from 'http';
+import type { AddressInfo } from 'net';
+import * as crypto from 'crypto';
+
+const logger = createLogger('GithubStatusSteps');
+
+type AnyDriver = any;
+
+type StubRequest = {
+    method: string | undefined;
+    url: string | undefined;
+    headers: http.IncomingHttpHeaders;
+    body: string;
+};
+
+const CHECK_PARAMS = { os: 'macOS', browserName: 'chrome', browserVersion: '120', viewport: '1366x768' };
+
+function idOf(value: any): string {
+    return value?._id || value?.id || value;
+}
+
+Given(
+    'I start a GitHub status stub server',
+    async ({ appServer, testData }: { appServer: AppServerFixture; testData: TestStore }) => {
+        const requests: StubRequest[] = [];
+        const server = http.createServer((req, res) => {
+            let body = '';
+            req.on('data', (chunk) => { body += chunk; });
+            req.on('end', () => {
+                requests.push({ method: req.method, url: req.url, headers: req.headers, body });
+                logger.info(`GitHub status stub received ${req.method} ${req.url}`);
+                res.writeHead(201, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ state: 'success' }));
+            });
+        });
+
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+        const port = (server.address() as AddressInfo).port;
+
+        testData.set('githubStubServer', server);
+        testData.set('githubStubRequests', requests);
+
+        process.env.SYNGRISI_GITHUB_API_URL = `http://127.0.0.1:${port}`;
+        logger.info(`GitHub status stub listening on port ${port}, restarting server to apply SYNGRISI_GITHUB_API_URL`);
+        if (appServer.baseURL) {
+            await appServer.restart();
+        }
+    }
+);
+
+When(
+    'I start an SDK test session for app {string} with commit {string}',
+    async (
+        { testData }: { testData: TestStore },
+        app: string,
+        commit: string,
+    ) => {
+        const driver = testData.get('sdkDriver') as AnyDriver;
+        const branch = 'integration';
+        const params = {
+            app,
+            test: `Github Status Test ${crypto.randomUUID().slice(0, 8)}`,
+            run: 'github_status_run',
+            runident: crypto.randomUUID(),
+            branch,
+            suite: 'Github status suite',
+            tags: [],
+            commit,
+            ...CHECK_PARAMS,
+            browserFullVersion: '120.0.0.0',
+        };
+        const session = await driver.startTestSession({ params });
+        testData.set('sdkApp', app);
+        testData.set('sdkBranch', branch);
+        testData.set('sdkSession', session);
+        logger.info(`Started SDK session for app "${app}" with commit "${commit}" (testId=${idOf(session)})`);
+    }
+);
+
+Then(
+    'the GitHub status stub should have received a status POST for commit {string} with state {string}',
+    async ({ testData }: { testData: TestStore }, commit: string, state: string) => {
+        const requests = (testData.get('githubStubRequests') as StubRequest[]) || [];
+        await expect.poll(
+            () => requests.some((r) => (r.url || '').endsWith(`/statuses/${commit}`)),
+            { timeout: 10_000, message: `waiting for a status POST for commit "${commit}"` }
+        ).toBe(true);
+
+        const match = requests.find((r) => (r.url || '').endsWith(`/statuses/${commit}`));
+        expect(match, `no request found for commit "${commit}"; received: ${JSON.stringify(requests)}`).toBeTruthy();
+        expect(match!.method).toBe('POST');
+        expect(match!.headers['authorization']).toMatch(/^Bearer /);
+
+        const body = JSON.parse(match!.body);
+        expect(body.state).toBe(state);
+        expect(body.context).toBe('syngrisi/visual');
+        logger.info(`GitHub status stub received expected status POST: ${JSON.stringify(body)}`);
+    }
+);
+
+Then(
+    'the GitHub status stub should have received no requests',
+    async ({ testData }: { testData: TestStore }) => {
+        // Negative assertion: give the fire-and-forget notifier a moment to (not) fire.
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        const requests = (testData.get('githubStubRequests') as StubRequest[]) || [];
+        expect(requests, `expected no requests, received: ${JSON.stringify(requests)}`).toHaveLength(0);
+    }
+);

--- a/packages/syngrisi/e2e/steps/domain/http/baselines-backend.steps.ts
+++ b/packages/syngrisi/e2e/steps/domain/http/baselines-backend.steps.ts
@@ -1059,3 +1059,115 @@ When(
     expect(updated.matchType).toBe(matchType);
   }
 );
+
+// =============================================================================
+// Baseline "time machine": GET /v1/baselines/history and POST /v1/baselines/history-summary
+// =============================================================================
+
+When(
+  'I fetch via http baseline history for check {string}',
+  async (
+    { appServer, testData }: { appServer: AppServerFixture; testData: TestStore },
+    checkName: string
+  ) => {
+    // Read one existing baseline for this check to recover its ident (name/app/branch/
+    // browserName/viewport/os) - the history endpoint is looked up by ident, not by baseline id.
+    const nameFilter = encodeURIComponent(JSON.stringify({ name: checkName }));
+    const baselinesRes = await requestWithSession(
+      `${appServer.baseURL}/v1/baselines?limit=0&filter=${nameFilter}`,
+      testData,
+      appServer
+    );
+    const baselines = baselinesRes.json.results || [];
+    if (!baselines.length) {
+      throw new Error(`No baselines found for check "${checkName}"`);
+    }
+    const ident = {
+      name: baselines[0].name,
+      app: baselines[0].app,
+      branch: baselines[0].branch,
+      browserName: baselines[0].browserName,
+      viewport: baselines[0].viewport,
+      os: baselines[0].os,
+    };
+
+    const historyFilter = encodeURIComponent(JSON.stringify(ident));
+    const uri = `${appServer.baseURL}/v1/baselines/history?filter=${historyFilter}`;
+    logger.info(`Fetching baseline history from: ${uri}`);
+    const historyRes = await requestWithSession(uri, testData, appServer);
+    logger.info(`Baseline history for "${checkName}": ${JSON.stringify(historyRes.json)}`);
+    testData.set('baselineHistory', historyRes.json);
+  }
+);
+
+Then(
+  'the baseline history should have {int} items ordered by date',
+  async (
+    { testData }: { testData: TestStore },
+    expectedCount: number
+  ) => {
+    const history = (testData.get('baselineHistory') as any[]) || [];
+    expect(history.length).toBe(expectedCount);
+    for (let i = 1; i < history.length; i += 1) {
+      const prevTime = new Date(history[i - 1].createdDate).getTime();
+      const currTime = new Date(history[i].createdDate).getTime();
+      expect(currTime).toBeGreaterThanOrEqual(prevTime);
+    }
+  }
+);
+
+When(
+  'I request the baseline history summary for the last two history items',
+  async (
+    { appServer, testData }: { appServer: AppServerFixture; testData: TestStore }
+  ) => {
+    const history = (testData.get('baselineHistory') as any[]) || [];
+    expect(history.length).toBeGreaterThanOrEqual(2);
+    const fromBaselineId = history[history.length - 2].id;
+    const toBaselineId = history[history.length - 1].id;
+
+    const uri = `${appServer.baseURL}/v1/baselines/history-summary`;
+    logger.info(`Requesting history summary from ${fromBaselineId} to ${toBaselineId}`);
+    const result = await requestWithSession(uri, testData, appServer, {
+      method: 'POST',
+      json: { fromBaselineId, toBaselineId },
+    });
+    logger.info(`History summary result: ${JSON.stringify(result.json)}`);
+    testData.set('historySummaryResult', result.json);
+  }
+);
+
+Then(
+  'the baseline history summary should be null with reason {string}',
+  async (
+    { testData }: { testData: TestStore },
+    reason: string
+  ) => {
+    const result = testData.get('historySummaryResult') as any;
+    expect(result.summary).toBeNull();
+    expect(result.reason).toBe(reason);
+  }
+);
+
+Then(
+  'the baseline history summary should be a non-empty string',
+  async (
+    { testData }: { testData: TestStore }
+  ) => {
+    const result = testData.get('historySummaryResult') as any;
+    expect(typeof result.summary).toBe('string');
+    expect(result.summary.length).toBeGreaterThan(0);
+  }
+);
+
+Then(
+  'the baseline history summary should be cached',
+  async (
+    { testData }: { testData: TestStore }
+  ) => {
+    const result = testData.get('historySummaryResult') as any;
+    expect(result.cached).toBe(true);
+    expect(typeof result.summary).toBe('string');
+    expect(result.summary.length).toBeGreaterThan(0);
+  }
+);

--- a/packages/syngrisi/e2e/steps/domain/http/common-http.steps.ts
+++ b/packages/syngrisi/e2e/steps/domain/http/common-http.steps.ts
@@ -6,6 +6,7 @@ import { requestWithSession } from '@utils/http-client';
 import * as yaml from 'yaml';
 import { expect } from '@playwright/test';
 import { got } from 'got-cjs';
+import { renderTemplate } from '@helpers/template';
 
 const logger = createLogger('CommonHttpSteps');
 
@@ -216,3 +217,123 @@ When(
   }
 );
 
+
+// Generic first-match field assertion. Deliberately worded "to match:" (not
+// "matched:") to avoid colliding with the pre-existing ordinal-based
+// "I expect via http {ordinal} {string} filtered as {string} matched:" step,
+// which is ambiguously registered under both Then and When above and would
+// throw "Multiple definitions matched scenario step" if reused.
+Then(
+  'I expect via http {string} filtered as {string} to match:',
+  async (
+    { appServer, testData }: { appServer: AppServerFixture; testData: TestStore },
+    itemName: string,
+    filter: string,
+    yml: string
+  ) => {
+    const uri = `${appServer.baseURL}/v1/${itemName}s?limit=0&filter={"$and":${convertQueryToMongoFilter(filter)}}`;
+    logger.info(`Fetching ${itemName}s filtered as "${filter}"`);
+    const itemsResponse = await requestWithSession(uri, testData, appServer);
+    const items = itemsResponse.json.results;
+    const item = items[0];
+    if (!item) {
+      throw new Error(`${itemName} filtered as "${filter}" not found`);
+    }
+    const params = yaml.parse(yml);
+    expect(item).toMatchObject(params);
+  }
+);
+
+// Generic resource creator: POSTs the given YAML body to /v1/{itemName}s.
+// Used for resources (e.g. webhooks) that don't yet have a dedicated create step.
+When(
+  'I create via http {string} with params:',
+  async (
+    { appServer, testData }: { appServer: AppServerFixture; testData: TestStore },
+    itemName: string,
+    yml: string
+  ) => {
+    const rendered = renderTemplate(yml, testData);
+    const body = yaml.parse(rendered);
+    const uri = `${appServer.baseURL}/v1/${itemName}s`;
+    logger.info(`Creating ${itemName} via ${uri} with body: ${rendered}`);
+    const result = await requestWithSession(uri, testData, appServer, {
+      method: 'POST',
+      json: body,
+    });
+    const statusCode = result.raw?.statusCode;
+    logger.info(`${itemName} create status: ${statusCode}`);
+    expect(statusCode).toBeGreaterThanOrEqual(200);
+    expect(statusCode).toBeLessThan(300);
+  }
+);
+
+// Generic count assertion: counts /v1/{itemName}s matching the given field filter(s).
+Then(
+  'I expect via http that {string} filtered as {string} exist exactly {string} times',
+  async (
+    { appServer, testData }: { appServer: AppServerFixture; testData: TestStore },
+    itemName: string,
+    filter: string,
+    num: string
+  ) => {
+    const uri = `${appServer.baseURL}/v1/${itemName}s?limit=0&filter={"$and":${convertQueryToMongoFilter(filter)}}`;
+    logger.info(`Checking ${itemName}s filtered as "${filter}"`);
+    const itemsResponse = await requestWithSession(uri, testData, appServer);
+    const items = itemsResponse.json.results;
+    logger.info(`Found ${items.length} ${itemName}s`);
+    expect(items.length).toBe(parseInt(num, 10));
+  }
+);
+
+// Generic find-by-filter-then-PATCH, mirroring the "delete run by name" convention
+// (find the first match, then act on its id).
+When(
+  'I update via http {string} filtered as {string} with params:',
+  async (
+    { appServer, testData }: { appServer: AppServerFixture; testData: TestStore },
+    itemName: string,
+    filter: string,
+    yml: string
+  ) => {
+    const findUri = `${appServer.baseURL}/v1/${itemName}s?limit=0&filter={"$and":${convertQueryToMongoFilter(filter)}}`;
+    const found = await requestWithSession(findUri, testData, appServer);
+    const item = found.json.results?.[0];
+    if (!item?.id) {
+      throw new Error(`${itemName} filtered as "${filter}" not found for update`);
+    }
+    const rendered = renderTemplate(yml, testData);
+    const body = yaml.parse(rendered);
+    const uri = `${appServer.baseURL}/v1/${itemName}s/${item.id}`;
+    logger.info(`Updating ${itemName} "${item.id}" via ${uri} with body: ${rendered}`);
+    const result = await requestWithSession(uri, testData, appServer, {
+      method: 'PATCH',
+      json: body,
+    });
+    const statusCode = result.raw?.statusCode;
+    expect(statusCode).toBe(200);
+  }
+);
+
+// Generic find-by-filter-then-DELETE, mirroring the "delete run by name" convention.
+When(
+  'I delete via http {string} filtered as {string}',
+  async (
+    { appServer, testData }: { appServer: AppServerFixture; testData: TestStore },
+    itemName: string,
+    filter: string
+  ) => {
+    const findUri = `${appServer.baseURL}/v1/${itemName}s?limit=0&filter={"$and":${convertQueryToMongoFilter(filter)}}`;
+    const found = await requestWithSession(findUri, testData, appServer);
+    const item = found.json.results?.[0];
+    if (!item?.id) {
+      throw new Error(`${itemName} filtered as "${filter}" not found for deletion`);
+    }
+    const uri = `${appServer.baseURL}/v1/${itemName}s/${item.id}`;
+    logger.info(`Deleting ${itemName} "${item.id}" via ${uri}`);
+    const result = await requestWithSession(uri, testData, appServer, { method: 'DELETE' });
+    const statusCode = result.raw?.statusCode;
+    logger.info(`${itemName} "${item.id}" delete status: ${statusCode}`);
+    expect(statusCode).toBe(200);
+  }
+);

--- a/packages/syngrisi/e2e/support/utils/db-cleanup.ts
+++ b/packages/syngrisi/e2e/support/utils/db-cleanup.ts
@@ -134,8 +134,11 @@ export async function clearDatabase(
     }
   })());
 
-  // Task 2: Clear Baselines (if required)
-  if (removeBaselines && !softClean) {
+  // Task 2: Clear Baselines (if required). Runs in soft-clean mode too: the reused
+  // server reads image files on demand, and the snapshot documents referencing them
+  // are wiped by the same clean — keeping the files would leak state between
+  // scenarios (e.g. "expect exact N snapshot files" assertions).
+  if (removeBaselines) {
     tasks.push((async () => {
       try {
         await fs.rm(baselinesPath, { recursive: true, force: true });

--- a/packages/syngrisi/src/seeds/initialAppSettings.json
+++ b/packages/syngrisi/src/seeds/initialAppSettings.json
@@ -99,6 +99,7 @@
         "label": "AI Triage Provider",
         "description": "Model provider for AI Triage (type, baseUrl, apiKey, model)",
         "type": "AIProvider",
+        "env_variable": "SYNGRISI_AI_TRIAGE_PROVIDER_JSON",
         "value": {
             "type": "openai",
             "baseUrl": "",

--- a/packages/syngrisi/src/server/api-docs/openAPIDocumentGenerator.ts
+++ b/packages/syngrisi/src/server/api-docs/openAPIDocumentGenerator.ts
@@ -14,6 +14,7 @@ import { registry as settings } from '../routes/v1/settings.route';
 import { registry as testDistinct } from '../routes/v1/test_distinct.route';
 import { registry as client } from '../routes/v1/client.route';
 import { registry as snapshots } from '../routes/v1/snapshots.route';
+import { registry as webhooks } from '../routes/v1/webhooks.route';
 
 export function generateOpenAPIDocument() {
   const registry = new OpenAPIRegistry([
@@ -30,7 +31,8 @@ export function generateOpenAPIDocument() {
     settings,
     testDistinct,
     client,
-    snapshots
+    snapshots,
+    webhooks
   ]);
   const generator = new OpenApiGeneratorV3(registry.definitions);
 

--- a/packages/syngrisi/src/server/controllers/app.controller.ts
+++ b/packages/syngrisi/src/server/controllers/app.controller.ts
@@ -68,6 +68,7 @@ const updateTriagePolicy = catchAsync(async (req: Request, res: Response) => {
     if (req.body.triagePrompt !== undefined) set.triagePrompt = req.body.triagePrompt;
     if (req.body.triageExamples !== undefined) set.triageExamples = req.body.triageExamples;
     if (req.body.changeSimGate !== undefined) set.changeSimGate = Number(req.body.changeSimGate);
+    if (req.body.mainBranch !== undefined) set.mainBranch = req.body.mainBranch;
     const app = await App.findByIdAndUpdate(id, { $set: set }, { new: true }).exec();
     if (!app) {
         res.status(HttpStatus.NOT_FOUND).json({ error: 'App not found' });

--- a/packages/syngrisi/src/server/controllers/baseline.controller.ts
+++ b/packages/syngrisi/src/server/controllers/baseline.controller.ts
@@ -9,6 +9,7 @@ import { Response } from "express";
 import { ApiError } from '@utils';
 import { ExtRequest } from '@types';
 import { getUsageCountsBySnapshotIds, remove as removeBaseline } from '@services/baseline.service';
+import { getHistory, getHistorySummary, BaselineHistoryIdent } from '@services/baseline-history.service';
 
 const get = catchAsync(async (req: ExtRequest, res: Response) => {
     const filter = typeof req.query.filter === 'string'
@@ -82,9 +83,23 @@ const getDomSnapshot = catchAsync(async (req: ExtRequest, res: Response) => {
     res.json(content);
 });
 
+const getBaselineHistory = catchAsync(async (req: ExtRequest, res: Response) => {
+    const ident = deserializeIfJSON(String(req.query.filter)) as BaselineHistoryIdent;
+    const result = await getHistory(ident);
+    res.send(result);
+});
+
+const getBaselineHistorySummary = catchAsync(async (req: ExtRequest, res: Response) => {
+    const { fromBaselineId, toBaselineId } = req.body;
+    const result = await getHistorySummary(fromBaselineId, toBaselineId);
+    res.send(result);
+});
+
 export {
     get,
     put,
     remove,
     getDomSnapshot,
+    getBaselineHistory,
+    getBaselineHistorySummary,
 };

--- a/packages/syngrisi/src/server/controllers/client.controller.ts
+++ b/packages/syngrisi/src/server/controllers/client.controller.ts
@@ -14,7 +14,7 @@ const startSession = catchAsync(async (req: ExtRequest, res: Response) => {
     const params = pick(
         req.body,
         ['name', 'status', 'app', 'tags', 'branch', 'viewport', 'browser', 'browserVersion', 'browserFullVersion',
-            'os', 'run', 'runident', 'suite']
+            'os', 'run', 'runident', 'suite', 'commit']
     ) as ClientStartSessionType;
     const result = await clientService.startSession(params, String(req?.user?.username));
     res.send(result);

--- a/packages/syngrisi/src/server/controllers/webhook.controller.ts
+++ b/packages/syngrisi/src/server/controllers/webhook.controller.ts
@@ -1,0 +1,58 @@
+import { HttpStatus } from '@utils';
+import { ApiError, catchAsync, deserializeIfJSON, pick } from '@utils';
+import { webhookService } from '@services/webhook.service';
+import { Response } from "express";
+import { ExtRequest } from '@types';
+
+// Webhook `secret` is write-only: accepted on create/update but stripped here
+// before any response leaves the server, mirroring how settings.controller.ts
+// masks the AI provider apiKey.
+const stripSecret = (doc: any) => {
+    // Use toJSON() (not toObject()) so the model's toJSON plugin runs first
+    // (adds `id`, strips `__v`), then remove the write-only `secret` field.
+    const obj = doc?.toJSON ? doc.toJSON() : doc;
+    const { secret, ...rest } = obj;
+    return rest;
+};
+
+const get = catchAsync(async (req: ExtRequest, res: Response) => {
+    const filter = typeof req.query.filter === 'string'
+        ? deserializeIfJSON(req.query.filter) || {}
+        : {};
+
+    const options = pick(req.query, ['sortBy', 'limit', 'page']);
+    const result = await webhookService.getWebhooks(filter, options);
+    res.send({
+        ...result,
+        results: result.results.map(stripSecret),
+    });
+});
+
+const create = catchAsync(async (req: ExtRequest, res: Response) => {
+    const data = pick(req.body, ['url', 'events', 'secret', 'enabled']);
+    if (!data.url) throw new ApiError(HttpStatus.BAD_REQUEST, 'Cannot create webhook - "url" is required');
+    const webhook = await webhookService.createWebhook(data as { url: string; events?: string[]; secret?: string; enabled?: boolean });
+    res.status(HttpStatus.CREATED).send(stripSecret(webhook));
+});
+
+const update = catchAsync(async (req: ExtRequest, res: Response) => {
+    const { id } = req.params;
+    if (!id) throw new ApiError(HttpStatus.BAD_REQUEST, 'Cannot update webhook - Id not found');
+    const data = pick(req.body, ['url', 'events', 'secret', 'enabled']);
+    const webhook = await webhookService.updateWebhook(id, data);
+    res.send(stripSecret(webhook));
+});
+
+const remove = catchAsync(async (req: ExtRequest, res: Response) => {
+    const { id } = req.params;
+    if (!id) throw new ApiError(HttpStatus.BAD_REQUEST, 'Cannot remove webhook - Id not found');
+    const webhook = await webhookService.removeWebhook(id);
+    res.send(stripSecret(webhook));
+});
+
+export {
+    get,
+    create,
+    update,
+    remove,
+};

--- a/packages/syngrisi/src/server/envConfig.ts
+++ b/packages/syngrisi/src/server/envConfig.ts
@@ -110,4 +110,11 @@ export const env = cleanEnv(process.env, {
     // Custom Check Validator Plugin
     CHECK_MISMATCH_THRESHOLD: str({ default: '0' }),  // Mismatch % below which checks pass
     CHECK_VALIDATOR_SCRIPT: str({ default: '' }),     // Path to custom validation script
+
+    // GitHub commit-status integration: reports a run's outcome back to the commit as a status check.
+    // Dormant (zero requests) unless SYNGRISI_GITHUB_TOKEN, SYNGRISI_GITHUB_REPO and the run's commit are all present.
+    SYNGRISI_GITHUB_TOKEN: str({ default: '' }),          // Personal/fine-grained access token with `repo:status` scope
+    SYNGRISI_GITHUB_REPO: str({ default: '' }),           // '<owner>/<name>'
+    SYNGRISI_PUBLIC_URL: str({ default: '' }),            // Public base URL used as the status target_url
+    SYNGRISI_GITHUB_API_URL: str({ default: 'https://api.github.com' }), // Override for self-hosted GitHub Enterprise / tests
 });

--- a/packages/syngrisi/src/server/lib/startup/createInitialSettings.ts
+++ b/packages/syngrisi/src/server/lib/startup/createInitialSettings.ts
@@ -1,6 +1,31 @@
 import { appSettings } from "@settings";
 import { AppSettings as AppSettingsModel } from '@models';
+import log from "@logger";
 import initialAppSettings from '../../../seeds/initialAppSettings.json';
+
+const logOpts = {
+    scope: 'on_start',
+    msgType: 'SETUP',
+};
+
+// "Private AI" / headless provisioning: seed the AI Triage provider from an env JSON string
+// (see `env_variable` on the `ai_triage_provider` seed). Env wins over the stored value on
+// startup — the same env-over-admin precedence used by SYNGRISI_AI_TRIAGE_ENABLED.
+// Example: SYNGRISI_AI_TRIAGE_PROVIDER_JSON='{"type":"openai","baseUrl":"http://ollama:11434/v1","model":"gemma4:12b"}'
+async function seedTriageProviderFromEnv(): Promise<void> {
+    const raw = process.env.SYNGRISI_AI_TRIAGE_PROVIDER_JSON;
+    if (!raw) return;
+    try {
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            throw new Error('expected a JSON object');
+        }
+        await appSettings.set('ai_triage_provider', parsed);
+        log.info('AI Triage provider seeded from SYNGRISI_AI_TRIAGE_PROVIDER_JSON', logOpts);
+    } catch (e) {
+        log.error(`invalid SYNGRISI_AI_TRIAGE_PROVIDER_JSON, ignored: ${e}`, logOpts);
+    }
+}
 
 export async function createInitialSettings(): Promise<void> {
     const settings = appSettings;
@@ -16,4 +41,5 @@ export async function createInitialSettings(): Promise<void> {
         }
         await settings.init();
     }
+    await seedTriageProviderFromEnv();
 }

--- a/packages/syngrisi/src/server/models/App.model.ts
+++ b/packages/syngrisi/src/server/models/App.model.ts
@@ -29,6 +29,7 @@ export interface AppDocument extends Document {
     triagePrompt?: string; // full system-prompt override (empty → default built from verdicts)
     triageExamples?: Array<{ verdict: string; image: string; note?: string }>; // few-shot examples (data-URL images)
     changeSimGate?: number; // cosine cutoff for "same change at other resolutions" (per-project)
+    mainBranch?: string; // read-time baseline fallback: branch whose accepted baselines cover every other branch; empty = disabled
 }
 
 const AppSchema: Schema<AppDocument> = new Schema({
@@ -97,6 +98,9 @@ const AppSchema: Schema<AppDocument> = new Schema({
     },
     changeSimGate: {
         type: Number,
+    },
+    mainBranch: {
+        type: String,
     },
 });
 

--- a/packages/syngrisi/src/server/models/Baseline.model.ts
+++ b/packages/syngrisi/src/server/models/Baseline.model.ts
@@ -23,6 +23,11 @@ export interface BaselineDocument extends Document {
     matchType?: 'antialiasing' | 'nothing' | 'colors' | 'tolerant';
     toleranceThreshold?: number;
     meta?: Record<string, unknown>;
+    // Cached AI-generated description of the visual change vs the baseline that immediately
+    // precedes this one in its ident's accepted-baseline timeline (time machine feature).
+    // Keyed by fromBaselineId so a stale cache (computed against a different "from") is detected
+    // and regenerated rather than served incorrectly.
+    historySummary?: { fromBaselineId: string; text: string };
 }
 
 const BaselineSchema: Schema<BaselineDocument> = new Schema({
@@ -94,6 +99,9 @@ const BaselineSchema: Schema<BaselineDocument> = new Schema({
         max: 100,
     },
     meta: {
+        type: Object,
+    },
+    historySummary: {
         type: Object,
     },
 });

--- a/packages/syngrisi/src/server/models/Run.model.ts
+++ b/packages/syngrisi/src/server/models/Run.model.ts
@@ -12,6 +12,7 @@ export interface RunDocument extends Document {
     createdDate?: Date;
     parameters?: string[];
     meta?: Record<string, unknown>;
+    commit?: string;
 }
 
 const RunSchema: Schema<RunDocument> = new Schema({
@@ -44,6 +45,9 @@ const RunSchema: Schema<RunDocument> = new Schema({
     },
     meta: {
         type: Object,
+    },
+    commit: {
+        type: String,
     },
 });
 

--- a/packages/syngrisi/src/server/models/Webhook.model.ts
+++ b/packages/syngrisi/src/server/models/Webhook.model.ts
@@ -6,6 +6,7 @@ export interface WebhookDocument extends Document {
     url: string;
     events: string[];
     secret?: string;
+    enabled: boolean;
     createdDate?: Date;
     meta?: Record<string, unknown>;
 }
@@ -21,6 +22,10 @@ const WebhookSchema: Schema<WebhookDocument> = new Schema({
     },
     secret: {
         type: String,
+    },
+    enabled: {
+        type: Boolean,
+        default: true,
     },
     createdDate: {
         type: Date,

--- a/packages/syngrisi/src/server/routes/v1/baselines.route.ts
+++ b/packages/syngrisi/src/server/routes/v1/baselines.route.ts
@@ -3,7 +3,14 @@ import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
 import * as baselineController from '@controllers/baseline.controller';
 import { Midleware } from '@types';
 import { validateRequest } from '@utils/validateRequest';
-import { BaselineGetSchema, BaselinePutSchema } from '@schemas/Baseline.schema';
+import {
+    BaselineGetSchema,
+    BaselinePutSchema,
+    BaselineHistoryQuerySchema,
+    BaselineHistoryItemSchema,
+    HistorySummaryBodySchema,
+    HistorySummaryResponseSchema,
+} from '@schemas/Baseline.schema';
 import { createApiEmptyResponse, createApiResponse, createPaginatedApiResponse } from '@api-docs/openAPIResponseBuilders';
 import { ApiErrorSchema } from '@schemas/common/ApiError.schema';
 import { HttpStatus } from '@utils';
@@ -96,6 +103,38 @@ router.get(
     ensureLoggedInOrApiKey(),
     validateRequest(getByIdParamsSchema(), 'get, /v1/baselines/{id}/dom'),
     baselineController.getDomSnapshot as Midleware
+);
+
+registry.registerPath({
+    method: 'get',
+    path: '/v1/baselines/history',
+    summary: "Ordered accepted-baseline timeline for one check ident (baseline time machine)",
+    tags: ['Baselines'],
+    request: { query: BaselineHistoryQuerySchema },
+    responses: createApiResponse(BaselineHistoryItemSchema.array(), 'Success'),
+});
+
+router.get(
+    '/history',
+    ensureLoggedInOrApiKeyOrShareToken(),
+    validateRequest(createRequestQuerySchema(BaselineHistoryQuerySchema), 'get, /v1/baselines/history'),
+    baselineController.getBaselineHistory as Midleware
+);
+
+registry.registerPath({
+    method: 'post',
+    path: '/v1/baselines/history-summary',
+    summary: "AI-generated summary of the visual change between two baselines (baseline time machine)",
+    tags: ['Baselines'],
+    request: { body: createRequestOpenApiBodySchema(HistorySummaryBodySchema) },
+    responses: createApiResponse(HistorySummaryResponseSchema, 'Success'),
+});
+
+router.post(
+    '/history-summary',
+    ensureLoggedIn(),
+    validateRequest(createRequestBodySchema(HistorySummaryBodySchema), 'post, /v1/baselines/history-summary'),
+    baselineController.getBaselineHistorySummary as Midleware
 );
 
 export default router;

--- a/packages/syngrisi/src/server/routes/v1/index.route.ts
+++ b/packages/syngrisi/src/server/routes/v1/index.route.ts
@@ -16,6 +16,7 @@ import clientRoute from './client.route';
 import shareRoute from './share.route';
 import pluginSettingsRoute from './plugin-settings.route';
 import adminDataRoute from './admin-data.route';
+import webhooksRoute from './webhooks.route';
 
 const router = express.Router();
 
@@ -87,6 +88,10 @@ const defaultRoutes = [
     {
         path: '/admin/data',
         route: adminDataRoute,
+    },
+    {
+        path: '/webhooks',
+        route: webhooksRoute,
     },
 ];
 

--- a/packages/syngrisi/src/server/routes/v1/webhooks.route.ts
+++ b/packages/syngrisi/src/server/routes/v1/webhooks.route.ts
@@ -1,0 +1,91 @@
+import express from 'express';
+import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+import * as webhookController from '@controllers/webhook.controller';
+import { Midleware } from '@types';
+import { validateRequest } from '@utils/validateRequest';
+import { WebhookGetSchema, WebhookCreateSchema, WebhookUpdateSchema } from '@schemas/Webhook.schema';
+import { createApiResponse, createPaginatedApiResponse } from '@api-docs/openAPIResponseBuilders';
+import { ensureLoggedIn } from '@middlewares/ensureLogin';
+import { commonValidations } from '@schemas/utils';
+import { getByIdParamsSchema } from '@schemas/utils/createRequestParamsSchema';
+import { createRequestQuerySchema } from '@schemas/utils/createRequestQuerySchema';
+import { createRequestBodySchema } from '@schemas/utils/createRequestBodySchema';
+import { createRequestOpenApiBodySchema } from '@schemas/utils/createRequestOpenApiBodySchema';
+import { RequestPaginationSchema } from '@schemas/common/RequestPagination.schema';
+import { ApiErrorSchema } from '@schemas/common/ApiError.schema';
+import { HttpStatus } from '@utils';
+
+export const registry = new OpenAPIRegistry();
+const router = express.Router();
+
+registry.registerPath({
+    method: 'get',
+    path: '/v1/webhooks',
+    summary: "List of webhooks with pagination, and optional filtering and sorting.",
+    tags: ['Webhooks'],
+    request: { query: RequestPaginationSchema },
+    responses: createPaginatedApiResponse(WebhookGetSchema, 'Success'),
+});
+
+router.get(
+    '/',
+    ensureLoggedIn(),
+    validateRequest(createRequestQuerySchema(RequestPaginationSchema), 'get, /v1/webhooks'),
+    webhookController.get as Midleware
+);
+
+registry.registerPath({
+    method: 'post',
+    path: '/v1/webhooks',
+    summary: "Register a new webhook.",
+    tags: ['Webhooks'],
+    request: { body: createRequestOpenApiBodySchema(WebhookCreateSchema) },
+    responses: createApiResponse(WebhookGetSchema, 'Success', HttpStatus.CREATED),
+});
+
+router.post(
+    '/',
+    ensureLoggedIn(),
+    validateRequest(createRequestBodySchema(WebhookCreateSchema), 'post, /v1/webhooks'),
+    webhookController.create as Midleware
+);
+
+registry.registerPath({
+    method: 'patch',
+    path: '/v1/webhooks/{id}',
+    summary: "Update a webhook by ID.",
+    tags: ['Webhooks'],
+    request: { params: commonValidations.paramsId.params, body: createRequestOpenApiBodySchema(WebhookUpdateSchema) },
+    responses: {
+        ...createApiResponse(WebhookGetSchema, 'Success'),
+        ...createApiResponse(ApiErrorSchema, 'ApiError', HttpStatus.NOT_FOUND),
+    },
+});
+
+router.patch(
+    '/:id',
+    ensureLoggedIn(),
+    validateRequest(getByIdParamsSchema().merge(createRequestBodySchema(WebhookUpdateSchema)), 'patch, /v1/webhooks/{id}'),
+    webhookController.update as Midleware
+);
+
+registry.registerPath({
+    method: 'delete',
+    path: '/v1/webhooks/{id}',
+    summary: "Remove a webhook by ID.",
+    tags: ['Webhooks'],
+    request: commonValidations.paramsId,
+    responses: {
+        ...createApiResponse(WebhookGetSchema, 'Success'),
+        ...createApiResponse(ApiErrorSchema, 'ApiError', HttpStatus.NOT_FOUND),
+    },
+});
+
+router.delete(
+    '/:id',
+    ensureLoggedIn(),
+    validateRequest(getByIdParamsSchema(), 'delete, /v1/webhooks/{id}'),
+    webhookController.remove as Midleware
+);
+
+export default router;

--- a/packages/syngrisi/src/server/schemas/AppTriagePolicy.schema.ts
+++ b/packages/syngrisi/src/server/schemas/AppTriagePolicy.schema.ts
@@ -70,6 +70,9 @@ export const AppTriagePolicyUpdateSchema = z.object({
     triagePrompt: z.string().max(20000).optional(),
     triageExamples: z.array(TriageExampleSchema).max(20).optional(),
     changeSimGate: z.number().min(0).max(1).optional(),
+    // Read-time baseline fallback: branch whose accepted baselines cover every other branch for
+    // this project. Empty string clears it (feature disabled, preserving today's behavior).
+    mainBranch: z.string().max(255).optional(),
 }).strict();
 
 export type AppTriagePolicyUpdateType = z.infer<typeof AppTriagePolicyUpdateSchema>;

--- a/packages/syngrisi/src/server/schemas/Baseline.schema.ts
+++ b/packages/syngrisi/src/server/schemas/Baseline.schema.ts
@@ -122,4 +122,72 @@ const BaselinePutSchema = z.object({
 
 
 
-export { BaselineGetSchema, BaselinePutSchema };
+// Time machine: ident used to look up a check's accepted-baseline history. Unlike the SDK-facing
+// `client.route.ts` ident (where `app` is the app *name*), this mirrors how the UI already reads
+// baselines (`GET /v1/baselines`) - `app` is the App document's ObjectId.
+const BaselineHistoryIdentSchema = z.object({
+    name: z.string().min(1),
+    app: commonValidations.id,
+    branch: z.string().min(1),
+    browserName: z.string().min(1),
+    viewport: z.string().min(1),
+    os: z.string().min(1),
+});
+
+const BaselineHistoryFilterSchema = z
+    .string()
+    .refine((data) => {
+        try {
+            const parsed = JSON.parse(data);
+            BaselineHistoryIdentSchema.parse(parsed);
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }, {
+        message: 'Invalid JSON string or does not match the required ident schema',
+    })
+    .openapi({
+        description: 'Check ident (name, app id, branch, browserName, viewport, os) as a JSON string, used to look up its accepted-baseline history',
+        example: '{"name":"Login page","app":"6651dd45b9c3e1e0b8c1ce26","branch":"master","browserName":"chrome","viewport":"1366x768","os":"macOS"}',
+    });
+
+const BaselineHistoryQuerySchema = z.object({
+    filter: BaselineHistoryFilterSchema,
+});
+
+const BaselineHistoryItemSchema = z.object({
+    id: commonValidations.id,
+    createdDate: commonValidations.date,
+    markedByUsername: z.string().optional(),
+    filename: z.string().optional(),
+    imageUrl: z.string().optional(),
+});
+
+const HistorySummaryBodySchema = z.object({
+    fromBaselineId: commonValidations.id.openapi({
+        description: 'Older baseline id in the pair being compared',
+        example: '6651ec20917e9ce26f7c0849',
+    }),
+    toBaselineId: commonValidations.id.openapi({
+        description: 'Newer baseline id in the pair being compared',
+        example: '6651ec20917e9ce26f7c0850',
+    }),
+});
+
+const HistorySummaryResponseSchema = z.object({
+    summary: z.string().nullable(),
+    reason: z.string().optional(),
+    cached: z.boolean().optional(),
+});
+
+export {
+    BaselineGetSchema,
+    BaselinePutSchema,
+    BaselineHistoryIdentSchema,
+    BaselineHistoryFilterSchema,
+    BaselineHistoryQuerySchema,
+    BaselineHistoryItemSchema,
+    HistorySummaryBodySchema,
+    HistorySummaryResponseSchema,
+};

--- a/packages/syngrisi/src/server/schemas/Client.schema.ts
+++ b/packages/syngrisi/src/server/schemas/Client.schema.ts
@@ -49,7 +49,11 @@ const ClientStartSessionSchema = z.object({
     suite: z.string().min(1).openapi({
         description: 'Suite name',
         example: 'Smoke tests'
-    })
+    }),
+    commit: z.string().regex(/^[0-9a-fA-F]{7,40}$/).openapi({
+        description: 'Git commit SHA the run belongs to, used to report a commit status back to GitHub',
+        example: 'a1b2c3d'
+    }).optional()
 });
 
 export type ClientStartSessionType = z.infer<typeof ClientStartSessionSchema>

--- a/packages/syngrisi/src/server/schemas/Webhook.schema.ts
+++ b/packages/syngrisi/src/server/schemas/Webhook.schema.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { commonValidations } from './utils';
+
+extendZodWithOpenApi(z);
+
+const WebhookEventSchema = z.enum(['check.created', 'check.updated', 'test.finished']);
+
+// Returned by GET/list/create/update. `secret` is intentionally never included -
+// it is write-only (see WebhookCreateSchema/WebhookUpdateSchema) and masked by the controller.
+const WebhookGetSchema = z.object({
+    _id: commonValidations.id,
+    id: commonValidations.id.openapi({
+        description: 'ID of the webhook',
+        example: '666b3b828833d0cf24a670d7'
+    }),
+    url: z.string().url().openapi({
+        description: 'URL the webhook payload is POSTed to',
+        example: 'https://example.com/hooks/syngrisi'
+    }),
+    events: z.array(WebhookEventSchema).openapi({
+        description: 'Events this webhook is subscribed to',
+        example: ['check.created', 'check.updated']
+    }),
+    enabled: z.boolean().openapi({
+        description: 'Whether the webhook is active',
+        example: true
+    }),
+    createdDate: commonValidations.date.optional().openapi({
+        description: 'Creation date of the webhook',
+        example: '2024-06-13T18:33:38.617Z'
+    }),
+});
+
+const WebhookCreateSchema = z.object({
+    url: z.string().url().openapi({ example: 'https://example.com/hooks/syngrisi' }),
+    events: z.array(WebhookEventSchema).optional().openapi({ example: ['check.created', 'check.updated'] }),
+    secret: z.string().optional().openapi({ description: 'Write-only shared secret, never returned by GET' }),
+    enabled: z.boolean().optional().openapi({ example: true }),
+});
+
+const WebhookUpdateSchema = z.object({
+    url: z.string().url().optional(),
+    events: z.array(WebhookEventSchema).optional(),
+    secret: z.string().optional(),
+    enabled: z.boolean().optional(),
+});
+
+export { WebhookGetSchema, WebhookCreateSchema, WebhookUpdateSchema, WebhookEventSchema };

--- a/packages/syngrisi/src/server/services/baseline-history.service.ts
+++ b/packages/syngrisi/src/server/services/baseline-history.service.ts
@@ -1,0 +1,165 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { promises as fsp } from 'fs';
+import path from 'path';
+import { Baseline } from '@models';
+import { config } from '@config';
+import { appSettings } from '@settings';
+import log from '@logger';
+import { ApiError, HttpStatus } from '@utils';
+import { LogOpts } from '@types';
+import { createProvider } from './triage/factory';
+import { getProviderConfig } from './triage/config';
+import { TriageProviderConfig, VerdictDef } from './triage/types';
+
+export interface BaselineHistoryIdent {
+    name: string;
+    app: string;
+    branch: string;
+    browserName: string;
+    viewport: string;
+    os: string;
+}
+
+export interface BaselineHistoryItem {
+    id: string;
+    createdDate?: Date;
+    markedByUsername?: string;
+    filename?: string;
+    imageUrl?: string;
+}
+
+// "Time machine": the ordered timeline of accepted baselines for one check ident.
+export async function getHistory(ident: BaselineHistoryIdent): Promise<BaselineHistoryItem[]> {
+    const logOpts: LogOpts = { scope: 'baselineHistory', itemType: 'baseline', msgType: 'GET' };
+    // `app` is a plain ObjectId string here (see BaselineHistoryIdentSchema), same as every other
+    // ident-based Baseline query in this codebase (e.g. getAcceptedBaseline in baseline.service.ts)
+    // - cast needed because the generated Mongoose filter type wants an ObjectId, not a string.
+    const filter: any = { ...ident, markedAs: 'accepted' };
+    log.debug(`Get baseline history with filter: '${JSON.stringify(filter)}'`, logOpts);
+
+    const baselines: any[] = await Baseline.find(filter)
+        .sort({ createdDate: 1 })
+        .populate('snapshootId')
+        .exec();
+
+    return baselines.map((baseline) => {
+        const snapshot = baseline.snapshootId;
+        const filename = snapshot?.filename;
+        return {
+            id: baseline.id ?? baseline._id.toString(),
+            createdDate: baseline.createdDate,
+            markedByUsername: baseline.markedByUsername,
+            filename,
+            imageUrl: filename ? `/snapshoots/${filename}` : undefined,
+        };
+    });
+}
+
+async function getBase64(filename?: string): Promise<string | null> {
+    if (!filename) return null;
+    try {
+        const filePath = path.join(config.defaultImagesPath, filename);
+        return await fsp.readFile(filePath, { encoding: 'base64' });
+    } catch {
+        return null;
+    }
+}
+
+// A provider is considered "configured" for the summary feature when the *stored setting itself*
+// (not the env-overlaid runtime config `getProviderConfig()` returns) says so: the `fake` provider
+// always counts (deterministic, test-only), other types need an explicit apiKey or baseUrl in the
+// DB value. Reading the raw setting - rather than the merged config - keeps this check independent
+// of host env vars (e.g. a stray OPENAI_API_KEY in the environment) that legitimately apply to real
+// triage runs but shouldn't make "no provider configured" flaky for this feature's own settings-only
+// on/off signal.
+async function isProviderConfigured(): Promise<boolean> {
+    const raw = await appSettings.get('ai_triage_provider');
+    if (!raw || raw.enabled === false) return false;
+    const value = raw.value;
+    if (!value || typeof value !== 'object') return false;
+    if (value.type === 'fake') return true;
+    if (!value.type || value.type === 'openai') return Boolean(value.apiKey || value.baseUrl);
+    return true; // anthropic/gemini explicitly selected
+}
+
+// Single placeholder verdict - the summary feature repurposes the triage `classify()` call to get
+// a free-text `reason` describing the visual change; `verdict`/`confidence` are not used.
+const SUMMARY_VERDICTS: VerdictDef[] = [
+    { key: 'change_described', label: 'Change described', color: 'gray', severity: 1, autoAcceptable: false },
+];
+
+const SUMMARY_SYSTEM_PROMPT = `You are a visual-regression assistant. You are given two screenshots of the same page taken at different times: an OLDER baseline image and a NEWER baseline image.
+
+Describe, in one short sentence, what visually changed between them (e.g. "header redesigned with a new logo", "pricing table gained a new tier"). If nothing meaningfully changed, say so briefly.
+
+Return STRICT JSON only, no prose, with this exact shape:
+{"verdict": "change_described", "confidence": 0, "reason": "<one short sentence describing what changed>"}`;
+
+export interface HistorySummaryResult {
+    summary: string | null;
+    reason?: string;
+    cached?: boolean;
+}
+
+// AI-generated description of the visual change between two accepted baselines (time machine).
+// Cached on the newer baseline's `historySummary` field, keyed by the older baseline's id, so a
+// given pair is only ever summarized once.
+export async function getHistorySummary(fromBaselineId: string, toBaselineId: string): Promise<HistorySummaryResult> {
+    const logOpts: LogOpts = { scope: 'baselineHistorySummary', itemType: 'baseline', msgType: 'GET' };
+
+    const [fromBaseline, toBaseline]: any[] = await Promise.all([
+        Baseline.findById(fromBaselineId).populate('snapshootId').exec(),
+        Baseline.findById(toBaselineId).populate('snapshootId').exec(),
+    ]);
+    if (!fromBaseline) throw new ApiError(HttpStatus.NOT_FOUND, `cannot find baseline with id: '${fromBaselineId}'`);
+    if (!toBaseline) throw new ApiError(HttpStatus.NOT_FOUND, `cannot find baseline with id: '${toBaselineId}'`);
+
+    // The newer baseline (by createdDate) owns the cache slot, regardless of which id the caller
+    // passed as "from"/"to".
+    const fromTime = fromBaseline.createdDate ? new Date(fromBaseline.createdDate).getTime() : 0;
+    const toTime = toBaseline.createdDate ? new Date(toBaseline.createdDate).getTime() : 0;
+    const newer = toTime >= fromTime ? toBaseline : fromBaseline;
+    const older = toTime >= fromTime ? fromBaseline : toBaseline;
+    const olderId = older.id ?? older._id.toString();
+
+    const cached = newer.historySummary;
+    if (cached && cached.fromBaselineId === olderId) {
+        return { summary: cached.text, cached: true };
+    }
+
+    if (!(await isProviderConfigured())) {
+        return { summary: null, reason: 'no provider configured' };
+    }
+    const cfg = await getProviderConfig();
+    if (!cfg) {
+        return { summary: null, reason: 'no provider configured' };
+    }
+
+    const olderSnapshot: any = older.snapshootId;
+    const newerSnapshot: any = newer.snapshootId;
+    const [olderB64, newerB64] = await Promise.all([
+        getBase64(olderSnapshot?.filename),
+        getBase64(newerSnapshot?.filename),
+    ]);
+
+    let text: string;
+    try {
+        const result = await createProvider(cfg as TriageProviderConfig).classify({
+            name: newer.name,
+            baselineB64: olderB64,
+            actualB64: newerB64,
+            diffB64: null,
+            verdicts: SUMMARY_VERDICTS,
+            systemPrompt: SUMMARY_SYSTEM_PROMPT,
+        });
+        text = result.reason;
+    } catch (e) {
+        log.warn(`baseline history summary failed: ${e}`, logOpts);
+        return { summary: null, reason: 'summary generation failed' };
+    }
+
+    newer.historySummary = { fromBaselineId: olderId, text };
+    await newer.save();
+
+    return { summary: text, cached: false };
+}

--- a/packages/syngrisi/src/server/services/baseline.service.ts
+++ b/packages/syngrisi/src/server/services/baseline.service.ts
@@ -11,11 +11,29 @@ import { BaselineDocument } from '../models/Baseline.model';
 import { CreateCheckParamsExtended } from '../../types/Check';
 import { Types } from 'mongoose';
 
+async function findAcceptedBaselineByIdent(ident: IdentType) {
+    const identFieldsAccepted = Object.assign(buildIdentObject(ident), { markedAs: 'accepted' });
+    return Baseline.findOne(identFieldsAccepted, {}, { sort: { createdDate: -1 } });
+}
+
 export async function getAcceptedBaseline(params: IdentType) {
-    const identFieldsAccepted = Object.assign(buildIdentObject(params), { markedAs: 'accepted' });
-    const acceptedBaseline = await Baseline.findOne(identFieldsAccepted, {}, { sort: { createdDate: -1 } });
+    const acceptedBaseline = await findAcceptedBaselineByIdent(params);
     log.debug(`acceptedBaseline: '${acceptedBaseline ? JSON.stringify(acceptedBaseline) : 'not found'}'`, { itemType: 'baseline' });
     if (acceptedBaseline) return acceptedBaseline;
+
+    // Read-time fallback: no accepted baseline for this check's own branch. If the project has a
+    // configured main branch (and it differs from this check's branch), fall back to the main
+    // branch's accepted baseline instead of treating the check as new/not_accepted. Accepting a
+    // check still creates a baseline scoped to the check's own branch (see check.service.ts accept).
+    const app = await App.findById(params.app).select('mainBranch').lean();
+    if (app?.mainBranch && app.mainBranch !== params.branch) {
+        const fallbackBaseline = await findAcceptedBaselineByIdent({ ...params, branch: app.mainBranch });
+        if (fallbackBaseline) {
+            log.debug(`no accepted baseline for branch '${params.branch}', using main-branch ('${app.mainBranch}') fallback baseline: '${JSON.stringify(fallbackBaseline)}'`, { itemType: 'baseline' });
+            return fallbackBaseline;
+        }
+    }
+
     return null;
 }
 

--- a/packages/syngrisi/src/server/services/github-status.service.ts
+++ b/packages/syngrisi/src/server/services/github-status.service.ts
@@ -1,0 +1,92 @@
+import { Test } from '@models';
+import { RunDocument } from '@models/Run.model';
+import { env } from '@env';
+import log from '@logger';
+import { errMsg } from '@utils';
+
+type GithubState = 'pending' | 'success' | 'failure';
+
+const isConfigured = () => Boolean(env.SYNGRISI_GITHUB_TOKEN && env.SYNGRISI_GITHUB_REPO);
+
+/**
+ * Deep link to the run's grid in the index2 UI app, e.g.
+ * '<publicUrl>/?app=<appId>&base_filter={"run":{"$in":["<runId>"]}}'
+ */
+const buildTargetUrl = (run: RunDocument) => {
+    if (!env.SYNGRISI_PUBLIC_URL) {
+        return undefined;
+    }
+    const baseFilter = JSON.stringify({ run: { $in: [String(run._id)] } });
+    return `${env.SYNGRISI_PUBLIC_URL}/?app=${run.app}&base_filter=${encodeURIComponent(baseFilter)}`;
+};
+
+/**
+ * Aggregates the run's tests into a single GitHub commit-status state + description.
+ */
+const aggregateRunState = (statuses: (string | undefined)[]): { state: GithubState; description: string } => {
+    const passed = statuses.filter((s) => s === 'Passed').length;
+    const failed = statuses.filter((s) => s === 'Failed').length;
+    const newCount = statuses.filter((s) => s === 'New').length;
+    const running = statuses.filter((s) => s === 'Running').length;
+
+    let state: GithubState = 'success';
+    if (failed > 0) {
+        state = 'failure';
+    } else if (running > 0) {
+        state = 'pending';
+    }
+
+    const description = `${passed} passed, ${failed} failed, ${newCount} new`.slice(0, 140);
+    return { state, description };
+};
+
+/**
+ * Reports a run's aggregated status as a GitHub commit status.
+ * No-op (zero requests) unless SYNGRISI_GITHUB_TOKEN, SYNGRISI_GITHUB_REPO and the run's commit are all set.
+ * Errors are logged, never thrown - mirrors webhook.service's error posture.
+ */
+const notifyRunStatus = async (run: RunDocument): Promise<void> => {
+    if (!isConfigured() || !run.commit) {
+        return;
+    }
+
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const tests = await Test.find({ run: run._id } as any).lean().exec();
+        const { state, description } = aggregateRunState(tests.map((t) => t.status));
+
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+        const url = `${env.SYNGRISI_GITHUB_API_URL}/repos/${env.SYNGRISI_GITHUB_REPO}/statuses/${run.commit}`;
+
+        try {
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${env.SYNGRISI_GITHUB_TOKEN}`,
+                },
+                body: JSON.stringify({
+                    state,
+                    context: 'syngrisi/visual',
+                    description,
+                    target_url: buildTargetUrl(run),
+                }),
+                signal: controller.signal,
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+        } finally {
+            clearTimeout(timeoutId);
+        }
+    } catch (error) {
+        log.error(`Failed to report GitHub commit status for run '${run._id}': ${errMsg(error)}`);
+    }
+};
+
+export const githubStatusService = {
+    notifyRunStatus,
+};

--- a/packages/syngrisi/src/server/services/test-run.service.ts
+++ b/packages/syngrisi/src/server/services/test-run.service.ts
@@ -7,6 +7,7 @@ import { ClientStartSessionType } from '@schemas/Client.schema';
 import { UpdateTestType } from '@schemas/Test.schema';
 import { TestDocument } from '@models/Test.model';
 import { CheckDocument } from '@models/Check.model';
+import { webhookService } from './webhook.service';
 
 const updateTest = async (id: string, update: UpdateTestType) => {
     const logOpts: LogOpts = {
@@ -117,6 +118,7 @@ export const endSession = async (testId: string, username: string) => {
     log.info(`the session is over, the test will be updated with parameters: '${JSON.stringify(testParams)}'`, logOpts);
     const updatedTest = await updateTest(testId, testParams);
     const result = updatedTest?.toObject() as TestDocument;
+    webhookService.triggerWebhooks('test.finished', result).catch((e) => log.error(`Webhook error: ${errMsg(e)}`));
     return result;
 };
 

--- a/packages/syngrisi/src/server/services/test-run.service.ts
+++ b/packages/syngrisi/src/server/services/test-run.service.ts
@@ -1,5 +1,5 @@
 import { removeEmptyProperties, waitUntil, errMsg, calculateAcceptedStatus } from '@utils';
-import { Check, Test } from '@models';
+import { Check, Test, Run } from '@models';
 import { createRunIfNotExist, createSuiteIfNotExist, createItemIfNotExistAsync, createTest, updateItemDate } from '@lib/dbItems';
 import log from '@logger';
 import { LogOpts } from '@types';
@@ -8,6 +8,7 @@ import { UpdateTestType } from '@schemas/Test.schema';
 import { TestDocument } from '@models/Test.model';
 import { CheckDocument } from '@models/Check.model';
 import { webhookService } from './webhook.service';
+import { githubStatusService } from './github-status.service';
 
 const updateTest = async (id: string, update: UpdateTestType) => {
     const logOpts: LogOpts = {
@@ -57,10 +58,15 @@ export const startSession = async (params: ClientStartSessionType, username: str
         opts.app = app._id;
 
         const run = await createRunIfNotExist(
-            { name: params.run, ident: params.runident, app: app._id },
+            { name: params.run, ident: params.runident, app: app._id, commit: params.commit },
             { user: username, itemType: 'run' }
         );
         opts.run = run._id;
+
+        // Backfill the commit on a pre-existing run (createRunIfNotExist only sets it on insert)
+        if (params.commit && !run.commit) {
+            await Run.findByIdAndUpdate(run._id, { commit: params.commit }).exec();
+        }
 
         const suite = await createSuiteIfNotExist(
             { name: params.suite || 'Others', app: app._id, createdDate: new Date() },
@@ -119,6 +125,11 @@ export const endSession = async (testId: string, username: string) => {
     const updatedTest = await updateTest(testId, testParams);
     const result = updatedTest?.toObject() as TestDocument;
     webhookService.triggerWebhooks('test.finished', result).catch((e) => log.error(`Webhook error: ${errMsg(e)}`));
+    if (result?.run) {
+        Run.findById(result.run).exec()
+            .then((run) => run && githubStatusService.notifyRunStatus(run))
+            .catch((e) => log.error(`GitHub status error: ${errMsg(e)}`));
+    }
     return result;
 };
 

--- a/packages/syngrisi/src/server/services/webhook.service.ts
+++ b/packages/syngrisi/src/server/services/webhook.service.ts
@@ -1,8 +1,9 @@
 import { Webhook } from '@models';
+import { PaginateOptions } from '@models/plugins/utils';
 import log from '@logger';
 
 const triggerWebhooks = async (event: string, payload: any) => {
-    const webhooks = await Webhook.find({ events: event });
+    const webhooks = await Webhook.find({ events: event, enabled: { $ne: false } });
 
     for (const webhook of webhooks) {
         try {
@@ -36,6 +37,26 @@ const triggerWebhooks = async (event: string, payload: any) => {
     }
 };
 
+const getWebhooks = async (filter: Record<string, unknown>, options: PaginateOptions) => Webhook.paginate(filter, options);
+
+const createWebhook = async (data: { url: string; events?: string[]; secret?: string; enabled?: boolean }) => Webhook.create(data);
+
+const updateWebhook = async (id: string, data: Partial<{ url: string; events: string[]; secret: string; enabled: boolean }>) => {
+    const webhook = await Webhook.findByIdAndUpdate(id, data, { new: true }).exec();
+    if (!webhook) throw new Error(`cannot find webhook with id: ${id}`);
+    return webhook;
+};
+
+const removeWebhook = async (id: string) => {
+    const webhook = await Webhook.findByIdAndDelete(id).exec();
+    if (!webhook) throw new Error(`cannot find webhook with id: ${id}`);
+    return webhook;
+};
+
 export const webhookService = {
-    triggerWebhooks
+    triggerWebhooks,
+    getWebhooks,
+    createWebhook,
+    updateWebhook,
+    removeWebhook,
 };

--- a/packages/syngrisi/src/ui-app/admin/AdminLayout.tsx
+++ b/packages/syngrisi/src/ui-app/admin/AdminLayout.tsx
@@ -11,6 +11,7 @@ import AdminLogs from '@admin/components/Logs/AdminLogs';
 import AdminPluginSettings from '@admin/components/PluginSettings/AdminPluginSettings';
 import AdminDataManagement from '@admin/components/DataManagement/AdminDataManagement';
 import AdminAI from '@admin/components/AI/AdminAI';
+import AdminWebhooks from '@admin/components/Webhooks/AdminWebhooks';
 
 export default function AdminLayout() {
     const theme = useMantineTheme();
@@ -38,6 +39,7 @@ export default function AdminLayout() {
                             <Route path="settings" element={<AdminSettings />} />
                             <Route path="ai" element={<AdminAI />} />
                             <Route path="plugins" element={<AdminPluginSettings />} />
+                            <Route path="webhooks" element={<AdminWebhooks />} />
                             <Route path="logs" element={<AdminLogs />} />
                             <Route path="data" element={<AdminDataManagement />} />
                         </Routes>

--- a/packages/syngrisi/src/ui-app/admin/components/AI/AdminAI.tsx
+++ b/packages/syngrisi/src/ui-app/admin/components/AI/AdminAI.tsx
@@ -86,6 +86,7 @@ function PerProjectTriage() {
     const [prompt, setPrompt] = useState<string>('');
     const [examples, setExamples] = useState<Example[]>([]);
     const [simGate, setSimGate] = useState<number>(0.32);
+    const [mainBranch, setMainBranch] = useState<string>('');
     const [saving, setSaving] = useState(false);
 
     // Client-only stable render keys for the editable verdict/example rows, kept in a parallel
@@ -102,8 +103,8 @@ function PerProjectTriage() {
     const [confirmSwitchOpened, setConfirmSwitchOpened] = useState(false);
 
     const currentSnapshot = useMemo(
-        () => JSON.stringify({ enabled, mode, threshold, allow, verdicts, prompt, examples, simGate }),
-        [enabled, mode, threshold, allow, verdicts, prompt, examples, simGate],
+        () => JSON.stringify({ enabled, mode, threshold, allow, verdicts, prompt, examples, simGate, mainBranch }),
+        [enabled, mode, threshold, allow, verdicts, prompt, examples, simGate, mainBranch],
     );
     const isDirty = loadedSnapshot !== null && currentSnapshot !== loadedSnapshot;
 
@@ -118,6 +119,7 @@ function PerProjectTriage() {
         const nextPrompt = selected.triagePrompt ? selected.triagePrompt : buildDefaultPrompt(vlist);
         const nextExamples = Array.isArray(selected.triageExamples) ? selected.triageExamples : [];
         const nextSimGate = typeof selected.changeSimGate === 'number' ? selected.changeSimGate : 0.32;
+        const nextMainBranch = typeof selected.mainBranch === 'string' ? selected.mainBranch : '';
 
         setEnabled(nextEnabled);
         setMode(nextMode);
@@ -127,10 +129,11 @@ function PerProjectTriage() {
         setPrompt(nextPrompt);
         setExamples(nextExamples);
         setSimGate(nextSimGate);
+        setMainBranch(nextMainBranch);
         setVerdictRowIds(vlist.map(() => crypto.randomUUID()));
         setExampleRowIds(nextExamples.map(() => crypto.randomUUID()));
         setLoadedSnapshot(JSON.stringify({
-            enabled: nextEnabled, mode: nextMode, threshold: nextThreshold, allow: nextAllow, verdicts: vlist, prompt: nextPrompt, examples: nextExamples, simGate: nextSimGate,
+            enabled: nextEnabled, mode: nextMode, threshold: nextThreshold, allow: nextAllow, verdicts: vlist, prompt: nextPrompt, examples: nextExamples, simGate: nextSimGate, mainBranch: nextMainBranch,
         }));
     }, [selected]);
 
@@ -195,6 +198,7 @@ function PerProjectTriage() {
                 triagePrompt: prompt.trim() === buildDefaultPrompt(verdicts).trim() ? '' : prompt.trim(),
                 triageExamples: examples,
                 changeSimGate: simGate,
+                mainBranch: mainBranch.trim(),
             }, {}, 'AdminAI.savePerProject');
             if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
             successMsg({ message: 'Project AI Triage config saved' });
@@ -394,6 +398,31 @@ function PerProjectTriage() {
                         value={simGate}
                         onChange={(v) => setSimGate(typeof v === 'number' ? v : 0.32)}
                         data-test="ai-sim-gate"
+                        w={260}
+                        mb="md"
+                    />
+
+                    <Divider my="md" label={(
+                        <Group gap={4}>
+                            <Text size="sm">Branch baselines</Text>
+                            <HelpDoc
+                                title="Main branch"
+                                lines={[
+                                    'When a check on another branch has no accepted baseline of its own, it is compared against the main branch\'s accepted baseline instead of landing as new/not accepted.',
+                                    'Accepting a check always creates a baseline for its own branch — this only affects which baseline a check is compared against, at read time.',
+                                    'Leave empty to disable (today\'s behavior: every branch starts with zero accepted baselines).',
+                                ]}
+                            />
+                        </Group>
+                    )}
+                    />
+                    <TextInput
+                        label="Main branch"
+                        description="Branch whose accepted baselines are used as a fallback for every other branch"
+                        placeholder="e.g. main"
+                        value={mainBranch}
+                        onChange={(e) => setMainBranch(e.currentTarget.value)}
+                        data-test="ai-main-branch"
                         w={260}
                         mb="md"
                     />

--- a/packages/syngrisi/src/ui-app/admin/components/Navbar/AdminNavbar.tsx
+++ b/packages/syngrisi/src/ui-app/admin/components/Navbar/AdminNavbar.tsx
@@ -7,6 +7,7 @@ import {
     IconPlugConnected,
     IconDatabase,
     IconSparkles,
+    IconWebhook,
 } from '@tabler/icons-react';
 import { LinksGroup } from '@admin/components/Navbar/NavbarLinksGroup';
 import { taskLinks } from '@admin/components/Tasks/tasksList';
@@ -21,6 +22,7 @@ const navbarItems = [
     },
     { label: 'Data Management', icon: IconDatabase, link: '/admin/data' },
     { label: 'Plugins', icon: IconPlugConnected, link: '/admin/plugins' },
+    { label: 'Webhooks', icon: IconWebhook, link: '/admin/webhooks' },
     { label: 'AI', icon: IconSparkles, link: '/admin/ai' },
     { label: 'Settings', icon: IconSettings, link: '/admin/settings' },
 ];

--- a/packages/syngrisi/src/ui-app/admin/components/Webhooks/AdminWebhooks.tsx
+++ b/packages/syngrisi/src/ui-app/admin/components/Webhooks/AdminWebhooks.tsx
@@ -1,0 +1,346 @@
+/**
+ * Webhooks Admin Component
+ * Manage webhook registrations: URL, subscribed events, enabled flag and secret.
+ * `secret` is write-only: it can be set on create/update but the API never returns it.
+ */
+
+import * as React from 'react';
+import { useState } from 'react';
+import {
+    Table,
+    Badge,
+    Switch,
+    TextInput,
+    PasswordInput,
+    MultiSelect,
+    Button,
+    Group,
+    Stack,
+    Title,
+    Text,
+    Modal,
+    ActionIcon,
+    Loader,
+    Alert,
+} from '@mantine/core';
+import { IconWebhook, IconAlertCircle, IconPlus, IconTrash, IconPencil, IconRefresh } from '@tabler/icons-react';
+import { showNotification } from '@mantine/notifications';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { WebhooksService, IWebhook, IWebhookInput, WebhookEvent } from '@shared/services';
+
+const EVENT_OPTIONS: { value: WebhookEvent; label: string }[] = [
+    { value: 'check.created', label: 'check.created' },
+    { value: 'check.updated', label: 'check.updated' },
+    { value: 'test.finished', label: 'test.finished' },
+];
+
+const emptyForm: IWebhookInput = {
+    url: '',
+    events: ['check.created', 'check.updated'],
+    secret: '',
+    enabled: true,
+};
+
+function WebhookForm({
+    initial,
+    onSubmit,
+    onCancel,
+    submitting,
+}: {
+    initial: IWebhookInput;
+    onSubmit: (data: IWebhookInput) => void;
+    onCancel: () => void;
+    submitting: boolean;
+}) {
+    const [form, setForm] = useState<IWebhookInput>(initial);
+
+    return (
+        <Stack gap="md">
+            <TextInput
+                label="URL"
+                placeholder="https://example.com/hooks/syngrisi"
+                required
+                value={form.url}
+                onChange={(e) => setForm({ ...form, url: e.currentTarget.value })}
+            />
+            <MultiSelect
+                label="Events"
+                data={EVENT_OPTIONS}
+                value={form.events}
+                onChange={(value) => setForm({ ...form, events: value as WebhookEvent[] })}
+            />
+            <PasswordInput
+                label="Secret"
+                description="Write-only. Leave blank to keep the existing secret (or unset if creating new)."
+                placeholder="Shared secret sent via X-Syngrisi-Secret header"
+                value={form.secret}
+                onChange={(e) => setForm({ ...form, secret: e.currentTarget.value })}
+            />
+            <Switch
+                label="Enabled"
+                checked={Boolean(form.enabled)}
+                onChange={(e) => setForm({ ...form, enabled: e.currentTarget.checked })}
+            />
+            <Group justify="flex-end">
+                <Button variant="subtle" onClick={onCancel}>Cancel</Button>
+                <Button
+                    onClick={() => onSubmit(form)}
+                    disabled={!form.url || submitting}
+                    loading={submitting}
+                >
+                    Save
+                </Button>
+            </Group>
+        </Stack>
+    );
+}
+
+export default function AdminWebhooks() {
+    const queryClient = useQueryClient();
+    const [modalMode, setModalMode] = useState<'create' | 'edit' | null>(null);
+    const [editingWebhook, setEditingWebhook] = useState<IWebhook | null>(null);
+    const [deletingWebhook, setDeletingWebhook] = useState<IWebhook | null>(null);
+
+    const { data, isLoading, error, refetch, isFetching } = useQuery({
+        queryKey: ['webhooks'],
+        queryFn: () => WebhooksService.list(),
+    });
+
+    const invalidate = () => queryClient.invalidateQueries({ queryKey: ['webhooks'] });
+
+    const createMutation = useMutation({
+        mutationFn: (input: IWebhookInput) => WebhooksService.create(input),
+        onSuccess: () => {
+            invalidate();
+            setModalMode(null);
+            showNotification({ title: 'Webhook created', message: 'The webhook was registered.', color: 'green' });
+        },
+        onError: (err) => {
+            showNotification({
+                title: 'Error',
+                message: err instanceof Error ? err.message : 'Failed to create webhook',
+                color: 'red',
+                icon: <IconAlertCircle size={16} />,
+            });
+        },
+    });
+
+    const updateMutation = useMutation({
+        mutationFn: ({ id, data }: { id: string; data: Partial<IWebhookInput> }) => WebhooksService.update(id, data),
+        onSuccess: () => {
+            invalidate();
+            setModalMode(null);
+            setEditingWebhook(null);
+            showNotification({ title: 'Webhook updated', message: 'The webhook was updated.', color: 'green' });
+        },
+        onError: (err) => {
+            showNotification({
+                title: 'Error',
+                message: err instanceof Error ? err.message : 'Failed to update webhook',
+                color: 'red',
+                icon: <IconAlertCircle size={16} />,
+            });
+        },
+    });
+
+    const removeMutation = useMutation({
+        mutationFn: (id: string) => WebhooksService.remove(id),
+        onSuccess: () => {
+            invalidate();
+            setDeletingWebhook(null);
+            showNotification({ title: 'Webhook deleted', message: 'The webhook was removed.', color: 'green' });
+        },
+        onError: (err) => {
+            showNotification({
+                title: 'Error',
+                message: err instanceof Error ? err.message : 'Failed to delete webhook',
+                color: 'red',
+                icon: <IconAlertCircle size={16} />,
+            });
+        },
+    });
+
+    const handleToggleEnabled = (webhook: IWebhook, enabled: boolean) => {
+        updateMutation.mutate({ id: webhook.id, data: { enabled } });
+    };
+
+    if (isLoading) {
+        return (
+            <Stack align="center" p="xl">
+                <Loader />
+                <Text>Loading webhooks...</Text>
+            </Stack>
+        );
+    }
+
+    if (error) {
+        return (
+            <Alert icon={<IconAlertCircle size={16} />} title="Error" color="red">
+                Failed to load webhooks. Make sure you have admin permissions.
+            </Alert>
+        );
+    }
+
+    const webhooks = data?.results || [];
+
+    return (
+        <Stack gap="lg" p="md">
+            <Group justify="space-between">
+                <Group>
+                    <IconWebhook size={24} />
+                    <Title order={3}>Webhooks</Title>
+                </Group>
+                <Group>
+                    <ActionIcon
+                        title="reload webhooks"
+                        variant="subtle"
+                        onClick={() => refetch()}
+                        loading={isFetching}
+                    >
+                        <IconRefresh stroke={1} size={20} />
+                    </ActionIcon>
+                    <Button
+                        leftSection={<IconPlus size={16} />}
+                        onClick={() => setModalMode('create')}
+                    >
+                        Add Webhook
+                    </Button>
+                </Group>
+            </Group>
+
+            <Text c="dimmed" size="sm">
+                Webhooks receive a JSON payload (
+                <code>{'{ event, payload, timestamp }'}</code>
+                {' '}
+                ) via POST whenever a subscribed event fires, signed with the
+                {' '}
+                <code>X-Syngrisi-Secret</code>
+                {' '}
+                header.
+            </Text>
+
+            {webhooks.length === 0 ? (
+                <Alert color="gray">No webhooks registered yet.</Alert>
+            ) : (
+                <Table striped highlightOnHover withTableBorder>
+                    <Table.Thead>
+                        <Table.Tr>
+                            <Table.Th>URL</Table.Th>
+                            <Table.Th>Events</Table.Th>
+                            <Table.Th>Enabled</Table.Th>
+                            <Table.Th>Created</Table.Th>
+                            <Table.Th>Actions</Table.Th>
+                        </Table.Tr>
+                    </Table.Thead>
+                    <Table.Tbody>
+                        {webhooks.map((webhook) => (
+                            <Table.Tr key={webhook.id}>
+                                <Table.Td>
+                                    <Text size="sm" style={{ wordBreak: 'break-all' }}>{webhook.url}</Text>
+                                </Table.Td>
+                                <Table.Td>
+                                    <Group gap={4}>
+                                        {webhook.events.map((event) => (
+                                            <Badge key={event} variant="outline" size="sm">{event}</Badge>
+                                        ))}
+                                    </Group>
+                                </Table.Td>
+                                <Table.Td>
+                                    <Switch
+                                        checked={webhook.enabled}
+                                        onChange={(e) => handleToggleEnabled(webhook, e.currentTarget.checked)}
+                                    />
+                                </Table.Td>
+                                <Table.Td>
+                                    <Text size="sm" c="dimmed">
+                                        {webhook.createdDate ? new Date(webhook.createdDate).toLocaleString() : ''}
+                                    </Text>
+                                </Table.Td>
+                                <Table.Td>
+                                    <Group gap="xs">
+                                        <ActionIcon
+                                            variant="subtle"
+                                            title="Edit webhook"
+                                            onClick={() => {
+                                                setEditingWebhook(webhook);
+                                                setModalMode('edit');
+                                            }}
+                                        >
+                                            <IconPencil size={16} />
+                                        </ActionIcon>
+                                        <ActionIcon
+                                            variant="subtle"
+                                            color="red"
+                                            title="Delete webhook"
+                                            onClick={() => setDeletingWebhook(webhook)}
+                                        >
+                                            <IconTrash size={16} />
+                                        </ActionIcon>
+                                    </Group>
+                                </Table.Td>
+                            </Table.Tr>
+                        ))}
+                    </Table.Tbody>
+                </Table>
+            )}
+
+            <Modal
+                opened={modalMode !== null}
+                onClose={() => {
+                    setModalMode(null);
+                    setEditingWebhook(null);
+                }}
+                title={modalMode === 'edit' ? 'Edit Webhook' : 'Add Webhook'}
+            >
+                <WebhookForm
+                    initial={modalMode === 'edit' && editingWebhook
+                        ? { url: editingWebhook.url, events: editingWebhook.events, secret: '', enabled: editingWebhook.enabled }
+                        : emptyForm}
+                    submitting={createMutation.isPending || updateMutation.isPending}
+                    onCancel={() => {
+                        setModalMode(null);
+                        setEditingWebhook(null);
+                    }}
+                    onSubmit={(formData) => {
+                        // Don't send an empty secret on update - that would be
+                        // indistinguishable from "clear the secret" vs "leave it".
+                        const payload = { ...formData };
+                        if (modalMode === 'edit' && !payload.secret) {
+                            delete payload.secret;
+                        }
+                        if (modalMode === 'edit' && editingWebhook) {
+                            updateMutation.mutate({ id: editingWebhook.id, data: payload });
+                        } else {
+                            createMutation.mutate(payload);
+                        }
+                    }}
+                />
+            </Modal>
+
+            <Modal
+                opened={deletingWebhook !== null}
+                onClose={() => setDeletingWebhook(null)}
+                title="Delete Webhook"
+            >
+                <Stack gap="md">
+                    <Text>
+                        Are you sure you want to delete the webhook for
+                        {' '}
+                        <b>{deletingWebhook?.url}</b>
+                        ?
+                    </Text>
+                    <Group justify="flex-end">
+                        <Button variant="subtle" onClick={() => setDeletingWebhook(null)}>Cancel</Button>
+                        <Button
+                            color="red"
+                            loading={removeMutation.isPending}
+                            onClick={() => deletingWebhook && removeMutation.mutate(deletingWebhook.id)}
+                        >
+                            Delete
+                        </Button>
+                    </Group>
+                </Stack>
+            </Modal>
+        </Stack>
+    );
+}

--- a/packages/syngrisi/src/ui-app/index2/components/Baselines/Table/BaselinesHeads.tsx
+++ b/packages/syngrisi/src/ui-app/index2/components/Baselines/Table/BaselinesHeads.tsx
@@ -47,6 +47,7 @@ function BaselinesHeads({ flatData, toggleAllRows, selection, visibleFields }: P
                     },
                 )
             }
+            <th style={{ width: '1%' }} aria-label="Actions" />
         </tr>
     );
 }

--- a/packages/syngrisi/src/ui-app/index2/components/Baselines/Table/BaselinesRow.tsx
+++ b/packages/syngrisi/src/ui-app/index2/components/Baselines/Table/BaselinesRow.tsx
@@ -1,10 +1,15 @@
 /* eslint-disable no-underscore-dangle */
 import * as React from 'react';
-import { Checkbox, useMantineTheme, useComputedColorScheme } from '@mantine/core';
+import { useState } from 'react';
+import {
+    Checkbox, ActionIcon, Tooltip, useMantineTheme, useComputedColorScheme,
+} from '@mantine/core';
+import { IconHistory } from '@tabler/icons-react';
 import { baselinesTableColumns } from './baselinesTableColumns';
 import { BaselinesCellWrapper } from './BaselinesCellWrapper';
 import { testsCreateStyle } from '@index/components/Tests/Table/testsCreateStyle';
 import { useNavigate } from 'react-router';
+import { HistoryModal } from './Modals/HistoryModal';
 
 interface Props {
     item: any
@@ -28,6 +33,7 @@ export function BaselinesRow(
     const styles = testsCreateStyle(theme, colorScheme);
     const selected = selection.includes(item.id || item._id);
     const navigate = useNavigate();
+    const [historyOpened, setHistoryOpened] = useState(false);
 
     const handleRowClick = () => {
         // snapshootId is just an ObjectId string, not a populated document
@@ -66,6 +72,32 @@ export function BaselinesRow(
                     );
                 })
             }
+            <td onClick={(e) => e.stopPropagation()} style={{ width: '1%' }}>
+                <Tooltip label="History" withinPortal>
+                    <ActionIcon
+                        variant="subtle"
+                        color="gray"
+                        aria-label="History"
+                        data-test="baseline-history-button"
+                        onClick={() => setHistoryOpened(true)}
+                    >
+                        <IconHistory size={16} />
+                    </ActionIcon>
+                </Tooltip>
+                <HistoryModal
+                    opened={historyOpened}
+                    onClose={() => setHistoryOpened(false)}
+                    baselineName={item.name}
+                    ident={{
+                        name: item.name,
+                        app: item.app,
+                        branch: item.branch,
+                        browserName: item.browserName,
+                        viewport: item.viewport,
+                        os: item.os,
+                    }}
+                />
+            </td>
         </tr>
     );
 }

--- a/packages/syngrisi/src/ui-app/index2/components/Baselines/Table/Modals/HistoryModal.tsx
+++ b/packages/syngrisi/src/ui-app/index2/components/Baselines/Table/Modals/HistoryModal.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import {
+    Modal, Stack, Group, Text, Image, Slider, ActionIcon, Loader, Center,
+} from '@mantine/core';
+import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+import { useQuery } from '@tanstack/react-query';
+import * as dateFns from 'date-fns';
+import config from '@config';
+import { BaselineHistoryService, BaselineHistoryIdent } from '@shared/services/baselineHistory.service';
+
+interface HistoryModalProps {
+    opened: boolean;
+    onClose: () => void;
+    ident: BaselineHistoryIdent;
+    baselineName: string;
+}
+
+// "Time machine": scrub through a check's accepted-baseline history over time, with an optional
+// AI-generated summary of what changed between consecutive baselines.
+export function HistoryModal({ opened, onClose, ident, baselineName }: HistoryModalProps) {
+    const [index, setIndex] = useState(0);
+
+    const historyQuery = useQuery({
+        queryKey: ['baselineHistory', ident],
+        queryFn: () => BaselineHistoryService.getHistory(ident),
+        enabled: opened,
+    });
+
+    const items = historyQuery.data || [];
+
+    useEffect(() => {
+        if (opened && items.length > 0) {
+            setIndex(items.length - 1);
+        }
+    }, [opened, items.length]);
+
+    const current = items[index];
+    const previous = index > 0 ? items[index - 1] : undefined;
+
+    const summaryQuery = useQuery({
+        queryKey: ['baselineHistorySummary', previous?.id, current?.id],
+        queryFn: () => BaselineHistoryService.getSummary(previous!.id, current!.id),
+        enabled: Boolean(opened && previous && current),
+    });
+
+    const marks = useMemo(
+        () => items.map((item, i) => ({
+            value: i,
+            label: dateFns.format(new Date(item.createdDate), 'MMM d'),
+        })),
+        [items]
+    );
+
+    const handleClose = () => {
+        setIndex(0);
+        onClose();
+    };
+
+    return (
+        <Modal
+            opened={opened}
+            onClose={handleClose}
+            title={`History: ${baselineName}`}
+            centered
+            size="lg"
+            data-test="history-modal"
+        >
+            <Stack gap="md">
+                {historyQuery.isLoading && (
+                    <Center h={200}><Loader size="sm" /></Center>
+                )}
+                {historyQuery.isError && (
+                    <Text c="red">Failed to load baseline history</Text>
+                )}
+                {!historyQuery.isLoading && items.length === 0 && (
+                    <Text c="dimmed">No accepted baselines found for this check</Text>
+                )}
+                {current && (
+                    <>
+                        <Group justify="center" align="center" wrap="nowrap" gap="xs">
+                            <ActionIcon
+                                variant="subtle"
+                                aria-label="Previous baseline"
+                                data-test="history-prev"
+                                disabled={index === 0}
+                                onClick={() => setIndex((i) => Math.max(0, i - 1))}
+                            >
+                                <IconChevronLeft size={18} />
+                            </ActionIcon>
+                            <Image
+                                src={current.imageUrl ? `${config.baseUri}${current.imageUrl}` : ''}
+                                fit="contain"
+                                mah={360}
+                                data-test="history-image"
+                            />
+                            <ActionIcon
+                                variant="subtle"
+                                aria-label="Next baseline"
+                                data-test="history-next"
+                                disabled={index === items.length - 1}
+                                onClick={() => setIndex((i) => Math.min(items.length - 1, i + 1))}
+                            >
+                                <IconChevronRight size={18} />
+                            </ActionIcon>
+                        </Group>
+
+                        <Text size="sm" ta="center" c="dimmed" data-test="history-date">
+                            {dateFns.format(new Date(current.createdDate), 'yyyy-MM-dd HH:mm:ss')}
+                            {current.markedByUsername ? ` · accepted by ${current.markedByUsername}` : ''}
+                        </Text>
+
+                        {items.length > 1 && (
+                            <Slider
+                                value={index}
+                                onChange={setIndex}
+                                min={0}
+                                max={items.length - 1}
+                                step={1}
+                                marks={marks}
+                                label={(value) => (items[value]
+                                    ? dateFns.format(new Date(items[value].createdDate), 'MMM d, yyyy')
+                                    : '')}
+                                data-test="history-slider"
+                            />
+                        )}
+
+                        {previous && (
+                            <Stack gap={4} mt="md" data-test="history-summary">
+                                {summaryQuery.isLoading && <Loader size="xs" />}
+                                {summaryQuery.data?.summary && (
+                                    <Text size="sm">{summaryQuery.data.summary}</Text>
+                                )}
+                            </Stack>
+                        )}
+                    </>
+                )}
+            </Stack>
+        </Modal>
+    );
+}

--- a/packages/syngrisi/src/ui-app/shared/navigation/navigationData.tsx
+++ b/packages/syngrisi/src/ui-app/shared/navigation/navigationData.tsx
@@ -13,6 +13,7 @@ import {
     IconUser,
     IconUserExclamation,
     IconPhoto,
+    IconWebhook,
 } from '@tabler/icons-react';
 import { INavDataItem } from '@shared/navigation/interfaces';
 
@@ -133,6 +134,16 @@ export function navigationData(): INavDataItem[] {
             crumbs: [
                 { title: 'Admin', href: '/admin' },
                 { title: 'Data Management', href: '/admin/data' },
+            ],
+        },
+        {
+            title: 'Webhooks',
+            description: 'Manage webhook registrations',
+            group: 'admin',
+            icon: <IconWebhook size={18} />,
+            crumbs: [
+                { title: 'Admin', href: '/admin' },
+                { title: 'Webhooks', href: '/admin/webhooks' },
             ],
         },
         {

--- a/packages/syngrisi/src/ui-app/shared/services/baselineHistory.service.ts
+++ b/packages/syngrisi/src/ui-app/shared/services/baselineHistory.service.ts
@@ -1,0 +1,52 @@
+/**
+ * Baseline "time machine" API service.
+ *
+ * Fetches the ordered accepted-baseline timeline for one check ident, and an optional
+ * AI-generated summary of what changed between two consecutive baselines.
+ */
+import { http } from '@shared/lib/http';
+
+export interface BaselineHistoryIdent {
+    name: string;
+    app: string;
+    branch: string;
+    browserName: string;
+    viewport: string;
+    os: string;
+}
+
+export interface BaselineHistoryItem {
+    id: string;
+    createdDate: string;
+    markedByUsername?: string;
+    filename?: string;
+    imageUrl?: string;
+}
+
+export interface HistorySummaryResult {
+    summary: string | null;
+    reason?: string;
+    cached?: boolean;
+}
+
+export const BaselineHistoryService = {
+    async getHistory(ident: BaselineHistoryIdent): Promise<BaselineHistoryItem[]> {
+        const filter = encodeURIComponent(JSON.stringify(ident));
+        const resp = await http.get(
+            `/v1/baselines/history?filter=${filter}`,
+            {},
+            'BaselineHistoryService.getHistory'
+        );
+        return resp.json();
+    },
+
+    async getSummary(fromBaselineId: string, toBaselineId: string): Promise<HistorySummaryResult> {
+        const resp = await http.post(
+            '/v1/baselines/history-summary',
+            { fromBaselineId, toBaselineId },
+            {},
+            'BaselineHistoryService.getSummary'
+        );
+        return resp.json();
+    },
+};

--- a/packages/syngrisi/src/ui-app/shared/services/index.ts
+++ b/packages/syngrisi/src/ui-app/shared/services/index.ts
@@ -8,4 +8,6 @@ export { imagePreloadService, ImagePreloadService } from '@shared/services/image
 export { RCAService } from '@shared/services/rca.service';
 export { TriageService } from '@shared/services/triage.service';
 export { adminDataService } from '@shared/services/adminData.service';
+export { WebhooksService } from '@shared/services/webhooks.service';
 export type { ICheck } from '@shared/services/imagePreload.service';
+export type { IWebhook, IWebhookInput, WebhookEvent } from '@shared/services/webhooks.service';

--- a/packages/syngrisi/src/ui-app/shared/services/index.ts
+++ b/packages/syngrisi/src/ui-app/shared/services/index.ts
@@ -8,4 +8,5 @@ export { imagePreloadService, ImagePreloadService } from '@shared/services/image
 export { RCAService } from '@shared/services/rca.service';
 export { TriageService } from '@shared/services/triage.service';
 export { adminDataService } from '@shared/services/adminData.service';
+export { BaselineHistoryService } from '@shared/services/baselineHistory.service';
 export type { ICheck } from '@shared/services/imagePreload.service';

--- a/packages/syngrisi/src/ui-app/shared/services/webhooks.service.ts
+++ b/packages/syngrisi/src/ui-app/shared/services/webhooks.service.ts
@@ -1,0 +1,63 @@
+import config from '@config';
+import { http } from '@shared/lib/http';
+
+export type WebhookEvent = 'check.created' | 'check.updated' | 'test.finished';
+
+export interface IWebhook {
+    id: string;
+    url: string;
+    events: WebhookEvent[];
+    enabled: boolean;
+    createdDate?: string;
+}
+
+export interface IWebhookListResult {
+    results: IWebhook[];
+    page: number;
+    limit: number;
+    totalPages: number;
+    totalResults: number;
+}
+
+export interface IWebhookInput {
+    url: string;
+    events: WebhookEvent[];
+    // Write-only: accepted here, never returned by the API.
+    secret?: string;
+    enabled?: boolean;
+}
+
+export const WebhooksService = {
+    async list(): Promise<IWebhookListResult> {
+        const resp = await http.get<IWebhookListResult>(
+            `${config.baseUri}/v1/webhooks?limit=0`,
+            {},
+            'WebhooksService.list'
+        );
+        return resp.json();
+    },
+
+    async create(data: IWebhookInput): Promise<IWebhook> {
+        const resp = await http.post<IWebhook>(
+            `${config.baseUri}/v1/webhooks`,
+            data,
+            {},
+            'WebhooksService.create'
+        );
+        return resp.json();
+    },
+
+    async update(id: string, data: Partial<IWebhookInput>): Promise<IWebhook> {
+        const resp = await http.patch<IWebhook>(
+            `${config.baseUri}/v1/webhooks/${id}`,
+            data,
+            {},
+            'WebhooksService.update'
+        );
+        return resp.json();
+    },
+
+    async remove(id: string): Promise<void> {
+        await http.delete(`${config.baseUri}/v1/webhooks/${id}`, {}, 'WebhooksService.remove');
+    },
+};

--- a/packages/wdio-sdk/src/WDIODriver.ts
+++ b/packages/wdio-sdk/src/WDIODriver.ts
@@ -101,7 +101,8 @@ export class WDIODriver {
                 suite: params.suite || 'Unknown',
                 tags: params.tags,
 
-                browserFullVersion: params.browserFullVersion || await getBrowserFullVersion()
+                browserFullVersion: params.browserFullVersion || await getBrowserFullVersion(),
+                commit: params.commit
             }
 
             // noinspection DuplicatedCode

--- a/packages/wdio-sdk/src/schemas/WDIODriver.ts
+++ b/packages/wdio-sdk/src/schemas/WDIODriver.ts
@@ -37,7 +37,8 @@ export const SessionParamsSchema = z.object({
     browserName: z.string().min(1).optional(),
     browserVersion: z.string().min(1).optional(),
     browserFullVersion: z.string().min(1).optional(),
-    tags: z.array(z.string()).optional()
+    tags: z.array(z.string()).optional(),
+    commit: z.string().regex(/^[0-9a-fA-F]{7,40}$/).optional(), // Git commit SHA, used to report a commit status back to GitHub
 }).catchall(z.union([z.string(), z.array(z.string()), z.undefined()]))
 
 export type SessionParams = z.infer<typeof SessionParamsSchema>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1641,6 +1641,11 @@
     "@shikijs/types" "^3.23.0"
     "@shikijs/vscode-textmate" "^10.0.2"
 
+"@hono/node-server@^1.19.9":
+  version "1.19.14"
+  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.14.tgz#e30f844bc77e3ce7be442aac3b1f73ad8b58d181"
+  integrity sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==
+
 "@humanfs/core@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.1.tgz#17c55ca7d426733fe3c561906b8173c336b40a77"
@@ -2248,6 +2253,29 @@
     fs-extra "^8.1.0"
     globby "^11.0.0"
     read-yaml-file "^1.1.0"
+
+"@modelcontextprotocol/sdk@^1.29.0":
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz#79786d8b525e269de850ac82b1f1f757f3915f44"
+  integrity sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==
+  dependencies:
+    "@hono/node-server" "^1.19.9"
+    ajv "^8.17.1"
+    ajv-formats "^3.0.1"
+    content-type "^1.0.5"
+    cors "^2.8.5"
+    cross-spawn "^7.0.5"
+    eventsource "^3.0.2"
+    eventsource-parser "^3.0.0"
+    express "^5.2.1"
+    express-rate-limit "^8.2.1"
+    hono "^4.11.4"
+    jose "^6.1.3"
+    json-schema-typed "^8.0.2"
+    pkce-challenge "^5.0.0"
+    raw-body "^3.0.0"
+    zod "^3.25 || ^4.0"
+    zod-to-json-schema "^3.25.1"
 
 "@mongodb-js/saslprep@^1.3.0":
   version "1.3.2"
@@ -3948,6 +3976,13 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
+ajv-formats@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-3.0.1.tgz#3d5dc762bca17679c3c2ea7e90ad6b7532309578"
+  integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv@^6.14.0:
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.15.0.tgz#07e982c74626167aa7a2495c53817892d7139492"
@@ -3957,6 +3992,16 @@ ajv@^6.14.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+ajv@^8.0.0, ajv@^8.17.1:
+  version "8.20.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz#304b3636add88ba7d936760dd50ece006dea95f9"
+  integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
 
 ansi-colors@^4.1.1, ansi-colors@^4.1.3:
   version "4.1.3"
@@ -5177,6 +5222,14 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
+cors@^2.8.5:
+  version "2.8.6"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.6.tgz#ff5dd69bd95e547503820d29aba4f8faf8dfec96"
+  integrity sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 cosmiconfig@9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-9.0.0.tgz#34c3fc58287b915f3ae905ab6dc3de258b55ad9d"
@@ -6056,6 +6109,18 @@ events-universal@^1.0.0:
   dependencies:
     bare-events "^2.7.0"
 
+eventsource-parser@^3.0.0, eventsource-parser@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.1.0.tgz#4e198eb91cd333d0a8ddcc036502b3618a25f449"
+  integrity sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==
+
+eventsource@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-3.0.7.tgz#1157622e2f5377bb6aef2114372728ba0c156989"
+  integrity sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==
+  dependencies:
+    eventsource-parser "^3.0.1"
+
 execa@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.0.0.tgz#4029b0007998a841fbd1032e5f4de86a3c1e3376"
@@ -6088,7 +6153,7 @@ express-fileupload@^1.5.2:
   dependencies:
     busboy "^1.6.0"
 
-express-rate-limit@^8.5.2:
+express-rate-limit@^8.2.1, express-rate-limit@^8.5.2:
   version "8.5.2"
   resolved "https://registry.yarnpkg.com/express-rate-limit/-/express-rate-limit-8.5.2.tgz#5922dbf76df2124611cea955d93432b37514b2f3"
   integrity sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==
@@ -6205,6 +6270,11 @@ fast-string-width@^3.0.2:
   integrity sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==
   dependencies:
     fast-string-truncated-width "^3.0.2"
+
+fast-uri@^3.0.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.3.tgz#f695a40f006aba505631573a0021ddb21194ad11"
+  integrity sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==
 
 fast-wrap-ansi@^0.2.0:
   version "0.2.2"
@@ -6843,6 +6913,11 @@ helmet@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/helmet/-/helmet-8.2.0.tgz#61cb43244de24255a288c2fddb36086074eb1812"
   integrity sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==
+
+hono@^4.11.4:
+  version "4.12.27"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.27.tgz#d9527b2c6e1da331731610889d1ddaea2c1d2b40"
+  integrity sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==
 
 hosted-git-info@^2.1.4:
   version "2.8.9"
@@ -7584,7 +7659,7 @@ jiti@^2.6.1:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.6.1.tgz#178ef2fc9a1a594248c20627cd820187a4d78d92"
   integrity sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==
 
-jose@^6.2.3:
+jose@^6.1.3, jose@^6.2.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/jose/-/jose-6.2.3.tgz#0975197ad973251221c658a3cddc4b951a250c2d"
   integrity sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==
@@ -7658,6 +7733,16 @@ json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
+json-schema-typed@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/json-schema-typed/-/json-schema-typed-8.0.2.tgz#e98ee7b1899ff4a184534d1f167c288c66bbeff4"
+  integrity sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -8990,7 +9075,7 @@ oauth@0.10.x:
   resolved "https://registry.yarnpkg.com/oauth/-/oauth-0.10.2.tgz#fd7139b0ce1a1037bd11fa4e236afc588132418c"
   integrity sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==
 
-object-assign@^4.0.1:
+object-assign@^4, object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -9636,6 +9721,11 @@ pirates@^4.0.1, pirates@^4.0.6:
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.7.tgz#643b4a18c4257c8a65104b73f3049ce9a0a15e22"
   integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
 
+pkce-challenge@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/pkce-challenge/-/pkce-challenge-5.0.1.tgz#3b4446865b17b1745e9ace2016a31f48ddf6230d"
+  integrity sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==
+
 pkg-dir@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
@@ -9904,7 +9994,7 @@ range-parser@^1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-raw-body@^3.0.1:
+raw-body@^3.0.0, raw-body@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-3.0.2.tgz#3e3ada5ae5568f9095d84376fd3a49b8fb000a51"
   integrity sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==
@@ -10175,6 +10265,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 require-main-filename@^2.0.0:
   version "2.0.0"
@@ -11790,7 +11885,7 @@ validate-npm-package-name@^7.0.0:
   resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-7.0.0.tgz#3b4fe12b4abfb8b0be010d0e75b1fe2b52295bc6"
   integrity sha512-bwVk/OK+Qu108aJcMAEiU4yavHUI7aN20TgZNBj9MR2iU1zPUl1Z1Otr7771ExfYTPTvfN8ZJ1pbr5Iklgt4xg==
 
-vary@^1.1.2, vary@~1.1.2:
+vary@^1, vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
@@ -12325,6 +12420,16 @@ yoga-layout@~3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/yoga-layout/-/yoga-layout-3.2.1.tgz#d2d1ba06f0e81c2eb650c3e5ad8b0b4adde1e843"
   integrity sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==
+
+zod-to-json-schema@^3.25.1:
+  version "3.25.2"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz#3fa799a7badd554541472fb65843fdc460b2e5aa"
+  integrity sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==
+
+"zod@^3.25 || ^4.0":
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==
 
 zod@^4.1.13:
   version "4.1.13"


### PR DESCRIPTION
Six features executed as self-contained plans (each by an isolated executor in a git worktree, each reviewed against its plan) merged into one integration branch, plus one e2e-harness fix found during integration testing.

## Features

- **Webhooks management** (`24115d77`): CRUD API `/v1/webhooks` + admin UI page + new `test.finished` event from `endSession`. Secret is write-only. Docs: `docs/WEBHOOKS.md`.
- **GitHub commit-status** (`a9301506`): optional `commit` param through the whole SDK chain (core-api → playwright-sdk/wdio-sdk → server → Run); on session end Syngrisi POSTs an aggregated commit status (`syngrisi/visual`, pending→success/failure) with a deep link to the run grid. Dormant unless `SYNGRISI_GITHUB_TOKEN`/`_REPO` set; token never logged/persisted.
- **Branch baseline fallback** (`ab59553f`): per-project `mainBranch`; a check on a feature branch without its own accepted baseline is compared against the main branch's baseline instead of landing as `new`. Accepts stay branch-scoped. Docs: `docs/BRANCH_BASELINES.md`.
- **`@syngrisi/mcp`** (`2af5103b`): official MCP server package — AI agents (Claude Code, Cursor) can list runs, inspect failed checks, view baseline/actual/diff images and accept checks over stdio. Stub-tested + live-smoked against a real server.
- **Baseline Time machine** (`d784a41e`): `GET /v1/baselines/history` + history slider modal on the Baselines page; optional AI change summaries via the existing triage provider (cached per pair). Docs: `docs/TIME_MACHINE.md`.
- **Private AI docker profile** (`b7f9b83e`): `docker compose --profile ai up` bundles Ollama (`OLLAMA_MODEL`, default `gemma4:12b`) + env-seeded triage provider (`SYNGRISI_AI_TRIAGE_PROVIDER_JSON`). Functional smoke ran a real local VLM triage (verdict `intended_change`, confidence 9).
- **Python SDK shipped** (`f45a1539`): `syngrisi-core-api` readied for PyPI (metadata, `PlaywrightDriver`, tests 35/35, twine PASSED, OIDC publish workflow — requires one-time PyPI trusted-publishing setup).

## Fix

- **e2e soft-clean file leak** (`0b832b41`): with fast-server reuse on by default, the soft clean between scenarios skipped the snapshot-files wipe, leaking files across scenarios (broke `AP/tasks` assertions). Files are now cleared in soft mode too.

## Verification (local, integration branch)

- Full parallel-phase e2e (everything except @sso/@flaky/@serial/@live-vlm), run in chunks: **331 passed, 1 flaky (retry-recovered), 0 failed** — AP 37, CHECKS_HANDLING+AI_TRIAGE+CHANGE_SIM 56, AUTH+INTEGRATION+M2M+PLUGINS 45, CP 146+1 flaky, MIXED+PERFORMANCE+RCA+ai_features 47.
- Unit tests 9/9; `@syngrisi/mcp` 7/7; Python SDK pytest 35/35.
- tsc error count unchanged vs main (141 pre-existing).

## Post-merge notes

- PyPI trusted publishing for `syngrisi-core-api` needs one-time maintainer setup before running `publish-python.yml`.
- First `docker compose --profile ai up` pulls the model via the `ollama-pull` one-shot service.
- Known limitation documented in `packages/mcp/README.md`: `/v1/runs` accepts session auth only (not API keys) on auth-enabled instances — candidate follow-up: switch it to `ensureLoggedInOrApiKey`.
- Changesets included: `@syngrisi/syngrisi` (webhooks, fallback, time machine, private-ai, commit-status), `@syngrisi/core-api`, `@syngrisi/playwright-sdk`, `@syngrisi/wdio-sdk`, `@syngrisi/mcp` — all minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)