### PR TITLE
feat: baseline promotion, per-project retention, official GitHub Action

### DIFF
--- a/.changeset/baseline-promotion-and-retention.md
+++ b/.changeset/baseline-promotion-and-retention.md
@@ -1,0 +1,8 @@
+---
+"@syngrisi/syngrisi": minor
+---
+
+Add baseline promotion and per-project retention.
+
+- **Baseline promotion on merge**: promote a feature branch's accepted baselines to the project's main branch via a new `POST /v1/baselines/promote` endpoint (accepts `{runId}` or `{app, fromBranch, toBranch?}`, CI-callable with an API key) and a "Promote baselines to main" action in the run kebab menu.
+- **Per-project retention**: auto-delete old checks per project, configured in Admin → Settings → Project settings (`retentionEnabled` / `retentionDays`). The cleanup scheduler now also runs per-project retention on top of the instance-wide policy.

--- a/.changeset/github-action-ci-docs.md
+++ b/.changeset/github-action-ci-docs.md
@@ -1,0 +1,5 @@
+---
+"@syngrisi/syngrisi": patch
+---
+
+Add an official `syngrisi-status` composite GitHub Action (poll `/v1/tests?filter={"run":...}` and gate the job on Passed/Failed/New) plus an example reusable workflow, and document the two-piece CI setup (server-side `commit` status via `startTestSession`, CI-side poll-and-gate) in a new `docs/CI.md` guide linked from the README.

--- a/.github/actions/syngrisi-status/action.yml
+++ b/.github/actions/syngrisi-status/action.yml
@@ -1,0 +1,175 @@
+name: 'Syngrisi Status Gate'
+description: 'Poll a Syngrisi run until it finishes and gate the job on its outcome (Passed/Failed/New).'
+author: 'Syngrisi'
+branding:
+  icon: 'eye'
+  color: 'purple'
+
+inputs:
+  syngrisi-url:
+    description: 'Base URL of the Syngrisi server, e.g. https://syngrisi.example.com'
+    required: true
+  api-key:
+    description: 'Syngrisi API key (sent as the raw `apikey` header).'
+    required: true
+  run-id:
+    description: 'The run id returned by startTestSession, used to filter /v1/tests.'
+    required: true
+  fail-on-new:
+    description: 'Fail the job if any test in the run is still `New` (no accepted baseline).'
+    required: false
+    default: 'false'
+  timeout-seconds:
+    description: 'Max time to wait for all tests in the run to leave the `Running` state.'
+    required: false
+    default: '300'
+  poll-interval-seconds:
+    description: 'Delay between polls.'
+    required: false
+    default: '5'
+
+outputs:
+  state:
+    description: '`success`, `failure`, or `pending` (timed out while still Running).'
+    value: ${{ steps.poll.outputs.state }}
+  passed:
+    description: 'Number of tests with status Passed.'
+    value: ${{ steps.poll.outputs.passed }}
+  failed:
+    description: 'Number of tests with status Failed.'
+    value: ${{ steps.poll.outputs.failed }}
+  new:
+    description: 'Number of tests with status New.'
+    value: ${{ steps.poll.outputs.new }}
+  total:
+    description: 'Total number of tests found for the run.'
+    value: ${{ steps.poll.outputs.total }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Poll Syngrisi run and gate
+      id: poll
+      shell: bash
+      env:
+        SYNGRISI_URL: ${{ inputs.syngrisi-url }}
+        SYNGRISI_API_KEY: ${{ inputs.api-key }}
+        SYNGRISI_RUN_ID: ${{ inputs.run-id }}
+        FAIL_ON_NEW: ${{ inputs.fail-on-new }}
+        TIMEOUT_SECONDS: ${{ inputs.timeout-seconds }}
+        POLL_INTERVAL_SECONDS: ${{ inputs.poll-interval-seconds }}
+      run: |
+        set -euo pipefail
+
+        if ! command -v jq >/dev/null 2>&1; then
+          echo "::error::jq is required by the syngrisi-status action but was not found on this runner." >&2
+          exit 1
+        fi
+
+        # URL-encode the MongoDB-style filter JSON (curl --data-urlencode style, via jq's @uri).
+        filter_json=$(printf '{"run":"%s"}' "$SYNGRISI_RUN_ID")
+        encoded_filter=$(jq -rn --arg v "$filter_json" '$v|@uri')
+        endpoint="${SYNGRISI_URL%/}/v1/tests?filter=${encoded_filter}&limit=1000"
+
+        deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+        response=""
+        timed_out="false"
+
+        echo "Polling ${SYNGRISI_URL%/}/v1/tests for run '${SYNGRISI_RUN_ID}' (timeout ${TIMEOUT_SECONDS}s, interval ${POLL_INTERVAL_SECONDS}s)..."
+
+        while true; do
+          http_code=""
+          body_file=$(mktemp)
+          if http_code=$(curl -sS -o "$body_file" -w '%{http_code}' -H "apikey: ${SYNGRISI_API_KEY}" "$endpoint" 2>/tmp/curl_err.log); then
+            :
+          else
+            http_code=""
+          fi
+
+          if [ "$http_code" = "200" ] && jq -e . "$body_file" >/dev/null 2>&1; then
+            response=$(cat "$body_file")
+            rm -f "$body_file"
+
+            running_count=$(echo "$response" | jq '[.results[]? | select(.status == "Running")] | length')
+
+            if [ "$running_count" -eq 0 ]; then
+              break
+            fi
+          else
+            echo "::warning::Request to Syngrisi failed (http_code='${http_code:-none}'), retrying... $(cat /tmp/curl_err.log 2>/dev/null || true)"
+            rm -f "$body_file"
+          fi
+
+          now=$(date +%s)
+          if [ "$now" -ge "$deadline" ]; then
+            timed_out="true"
+            break
+          fi
+
+          sleep "$POLL_INTERVAL_SECONDS"
+        done
+
+        if [ -z "$response" ]; then
+          echo "::error::Could not reach Syngrisi at ${SYNGRISI_URL} (or it never returned valid JSON) within ${TIMEOUT_SECONDS}s."
+          {
+            echo "state=failure"
+            echo "passed=0"
+            echo "failed=0"
+            echo "new=0"
+            echo "total=0"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "### Syngrisi status"
+            echo ""
+            echo "Could not reach Syngrisi (network error or no valid response) within ${TIMEOUT_SECONDS}s."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+        fi
+
+        total=$(echo "$response" | jq '.results? | length // 0')
+        passed=$(echo "$response" | jq '[.results[]? | select(.status == "Passed")] | length')
+        failed=$(echo "$response" | jq '[.results[]? | select(.status == "Failed")] | length')
+        new=$(echo "$response" | jq '[.results[]? | select(.status == "New")] | length')
+        running=$(echo "$response" | jq '[.results[]? | select(.status == "Running")] | length')
+
+        {
+          echo "passed=${passed}"
+          echo "failed=${failed}"
+          echo "new=${new}"
+          echo "total=${total}"
+        } >> "$GITHUB_OUTPUT"
+
+        state="success"
+        exit_code=0
+
+        if [ "$total" -eq 0 ]; then
+          echo "::warning::No tests found for run '${SYNGRISI_RUN_ID}'."
+        fi
+
+        if [ "$timed_out" = "true" ] && [ "$running" -gt 0 ]; then
+          state="pending"
+          echo "::error::Timed out after ${TIMEOUT_SECONDS}s waiting for ${running} test(s) still in 'Running' state (run '${SYNGRISI_RUN_ID}')."
+          exit_code=1
+        elif [ "$failed" -gt 0 ]; then
+          state="failure"
+          echo "::error::${failed} test(s) failed in run '${SYNGRISI_RUN_ID}'."
+          exit_code=1
+        elif [ "$new" -gt 0 ] && [ "$FAIL_ON_NEW" = "true" ]; then
+          state="failure"
+          echo "::error::${new} test(s) are 'New' (no accepted baseline) in run '${SYNGRISI_RUN_ID}' and fail-on-new is enabled."
+          exit_code=1
+        fi
+
+        echo "state=${state}" >> "$GITHUB_OUTPUT"
+
+        {
+          echo "### Syngrisi status: run \`${SYNGRISI_RUN_ID}\`"
+          echo ""
+          echo "| Total | Passed | Failed | New |"
+          echo "|---|---|---|---|"
+          echo "| ${total} | ${passed} | ${failed} | ${new} |"
+          echo ""
+          echo "Result: **${state}**"
+        } >> "$GITHUB_STEP_SUMMARY"
+
+        exit "$exit_code"

--- a/.github/workflows/syngrisi-example.yml
+++ b/.github/workflows/syngrisi-example.yml
@@ -1,0 +1,62 @@
+# Example — copy into your OWN repo. Not run in this repo.
+#
+# This workflow shows how to wire Syngrisi visual testing into GitHub Actions:
+#   1. Run your Playwright/Syngrisi tests, passing the current commit SHA into
+#      `startTestSession({ params: { commit: ... } })` so the Syngrisi server can
+#      post a `syngrisi/visual` commit status (requires SYNGRISI_GITHUB_TOKEN /
+#      SYNGRISI_GITHUB_REPO / SYNGRISI_PUBLIC_URL to be set on the Syngrisi server).
+#   2. Use the `syngrisi-status` composite action to poll the run's outcome and
+#      gate the job on it (Passed/Failed/New).
+#
+# See packages/syngrisi/docs/CI.md for the full guide.
+#
+# Trigger is workflow_dispatch only so this example never runs automatically
+# in the Syngrisi monorepo itself.
+name: Syngrisi Example
+
+on:
+  workflow_dispatch:
+
+jobs:
+  visual-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --ignore-engines
+
+      - name: Run visual tests
+        id: visual-tests
+        # Placeholder for your own Playwright/Syngrisi test command. Inside your
+        # test setup, pass the commit SHA so the Syngrisi server can report a
+        # commit status back to this PR:
+        #
+        #   await driver.startTestSession({
+        #     params: {
+        #       app: 'My App',
+        #       test: 'Homepage',
+        #       run: 'ci-run',
+        #       commit: '${{ github.event.pull_request.head.sha || github.sha }}',
+        #     },
+        #   });
+        #
+        # The SDK's `startTestSession` response includes the run id, e.g.:
+        #   const session = await driver.startTestSession({ params: { ... } });
+        #   core.setOutput('run-id', session.run); // expose it as a step output
+        run: |
+          echo "Replace this with: yarn test:visual"
+          echo "run-id=${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+
+      - name: Gate on Syngrisi result
+        uses: ./.github/actions/syngrisi-status
+        with:
+          syngrisi-url: ${{ secrets.SYNGRISI_URL }}
+          api-key: ${{ secrets.SYNGRISI_API_KEY }}
+          run-id: ${{ steps.visual-tests.outputs.run-id }}
+          fail-on-new: 'false'

--- a/README.md
+++ b/README.md
@@ -196,6 +196,32 @@ Also available: [`@syngrisi/wdio-sdk`](packages/wdio-sdk/README.md) for Webdrive
 Cucumber, and the framework-agnostic
 [`@syngrisi/core-api`](packages/core-api/README.md) REST client.
 
+### CI / GitHub Action
+
+Pass the commit SHA into `startTestSession` so the Syngrisi server can post a
+`syngrisi/visual` commit status on your PR (requires `SYNGRISI_GITHUB_TOKEN` /
+`SYNGRISI_GITHUB_REPO` / `SYNGRISI_PUBLIC_URL` on the server):
+
+```ts
+await driver.startTestSession({
+  params: { app: 'My App', test: 'Homepage', run: 'ci-run', commit: process.env.GITHUB_SHA },
+});
+```
+
+Then gate the job on the run's outcome with the bundled composite action:
+
+```yaml
+- name: Gate on Syngrisi result
+  uses: syngrisi/syngrisi/.github/actions/syngrisi-status@main
+  with:
+    syngrisi-url: ${{ secrets.SYNGRISI_URL }}
+    api-key: ${{ secrets.SYNGRISI_API_KEY }}
+    run-id: ${{ steps.visual-tests.outputs.run-id }}
+```
+
+See [CI Guide](packages/syngrisi/docs/CI.md) for the full setup, required env
+vars, and the `/v1/tests` poll API.
+
 ## ⚖️ How it compares
 
 | | **Syngrisi** | Applitools | Percy | Chromatic |
@@ -240,6 +266,7 @@ packages/
 - 🤖 [AI Features](packages/syngrisi/docs/AI_FEATURES.md) · [Root Cause Analysis](packages/syngrisi/docs/RCA.md)
 - 🧩 [Plugins](packages/syngrisi/docs/PLUGINS.md)
 - ⚙️ [Environment Variables](packages/syngrisi/docs/environment_variables.md)
+- 🔁 [CI / GitHub Action](packages/syngrisi/docs/CI.md)
 - 🛠️ [Development Guide](packages/syngrisi/docs/DEVELOPMENT.md) · [Release Cycle](docs-src/RELEASE_CYCLE.md)
 - 🔗 API reference: Swagger UI at `/swagger/` on a running instance.
 

--- a/packages/syngrisi/docs/CI.md
+++ b/packages/syngrisi/docs/CI.md
@@ -1,0 +1,119 @@
+# Running Syngrisi in CI
+
+There is no dedicated Syngrisi CI server component — everything below hangs off
+two existing pieces of the API:
+
+1. **Server-side commit status.** When you pass a git `commit` SHA into
+   `startTestSession`, and the Syngrisi server has `SYNGRISI_GITHUB_TOKEN` /
+   `SYNGRISI_GITHUB_REPO` configured, the server automatically posts a
+   `syngrisi/visual` [commit status](https://docs.github.com/en/rest/commits/statuses)
+   for that SHA (pending while the run is open, success/failure once it's
+   resolved). This is what shows up as a check on your PR.
+2. **CI-side poll-and-gate.** A CI job that started the run polls
+   `GET /v1/tests?filter={"run":"<runId>"}` until every test in the run has
+   left the `Running` state, then fails the job if anything failed. The
+   [`syngrisi-status`](../../../.github/actions/syngrisi-status/action.yml)
+   composite action does this for you.
+
+## 1. Attach the commit SHA when starting a session
+
+```ts
+const session = await driver.startTestSession({
+  params: {
+    app: 'My App',
+    test: 'Homepage',
+    run: 'ci-run',
+    branch: process.env.GITHUB_REF_NAME,
+    // The PR head SHA for pull_request events, otherwise the pushed SHA.
+    commit: process.env.GITHUB_SHA,
+  },
+});
+```
+
+`commit` must be a 7-40 character hex string (short or full SHA). The SDK
+forwards it as-is; the server does nothing with it unless the commit-status
+env vars below are set.
+
+### Required server-side env vars
+
+| Variable | Description |
+|---|---|
+| `SYNGRISI_GITHUB_TOKEN` | Personal/fine-grained GitHub token with `repo:status` scope. Never logged or persisted. |
+| `SYNGRISI_GITHUB_REPO` | The `<owner>/<name>` repository to post commit statuses to. |
+| `SYNGRISI_PUBLIC_URL` | Public base URL of this Syngrisi instance, used to build the `target_url` deep link on the commit status (points at the run's grid). |
+| `SYNGRISI_GITHUB_API_URL` | Optional. Override for the GitHub API base (GitHub Enterprise, or a stub in tests). Default: `https://api.github.com`. |
+
+This feature is dormant (zero requests) unless `SYNGRISI_GITHUB_TOKEN`,
+`SYNGRISI_GITHUB_REPO`, and the session's `commit` param are all present. See
+[`environment_variables.md`](environment_variables.md) for the full list.
+
+## 2. Gate the job on the run's outcome
+
+Copy [`.github/workflows/syngrisi-example.yml`](../../../.github/workflows/syngrisi-example.yml)
+and [`.github/actions/syngrisi-status/`](../../../.github/actions/syngrisi-status/)
+into your own repository, then reference the action from your workflow after
+your test step:
+
+```yaml
+- name: Run visual tests
+  id: visual-tests
+  run: yarn test:visual # your test command; exposes `run-id` as a step output
+
+- name: Gate on Syngrisi result
+  uses: ./.github/actions/syngrisi-status
+  with:
+    syngrisi-url: ${{ secrets.SYNGRISI_URL }}
+    api-key: ${{ secrets.SYNGRISI_API_KEY }}
+    run-id: ${{ steps.visual-tests.outputs.run-id }}
+```
+
+Your test step needs to expose the `run` value used in `startTestSession` as a
+step output (e.g. via `core.setOutput('run-id', session.run)` or
+`echo "run-id=$RUN" >> "$GITHUB_OUTPUT"`), so the gating step knows which run
+to poll for.
+
+### Action inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `syngrisi-url` | yes | — | Base URL of the Syngrisi server. |
+| `api-key` | yes | — | Syngrisi API key, sent as the raw `apikey` header. |
+| `run-id` | yes | — | The run id (the `run` value passed to `startTestSession`) to poll for. |
+| `fail-on-new` | no | `'false'` | Fail the job if any test in the run is still `New` (no accepted baseline). |
+| `timeout-seconds` | no | `'300'` | Max time to wait for all tests in the run to leave `Running`. |
+| `poll-interval-seconds` | no | `'5'` | Delay between polls. |
+
+### Action outputs
+
+| Output | Description |
+|---|---|
+| `state` | `success`, `failure`, or `pending` (timed out while tests were still `Running`). |
+| `passed` | Count of tests with status `Passed`. |
+| `failed` | Count of tests with status `Failed`. |
+| `new` | Count of tests with status `New`. |
+| `total` | Total number of tests found for the run. |
+
+The action requires only `curl` and `jq`, both preinstalled on GitHub-hosted
+runners.
+
+## The poll API
+
+```
+GET $SYNGRISI_URL/v1/tests?filter={"run":"<runId>"}
+Header: apikey: <raw api key>
+```
+
+`/v1/tests` accepts API-key auth (no session cookie required), which is what
+makes it usable from CI. The response is a paginated list; the fields that
+matter here are each item's `status`.
+
+`Test.status` vocabulary:
+
+| Status | Meaning |
+|---|---|
+| `Running` | The test session is still open — keep polling. |
+| `Passed` | The check(s) matched the accepted baseline. |
+| `Failed` | At least one check differed from the accepted baseline. |
+| `New` | No baseline exists yet for this check (nothing to compare against). |
+
+A run is "done" once no test in the filtered set has `status: "Running"`.

--- a/packages/syngrisi/e2e/features/AP/tasks/per_project_retention.feature
+++ b/packages/syngrisi/e2e/features/AP/tasks/per_project_retention.feature
@@ -1,0 +1,79 @@
+@fast-server
+Feature: Task - Per-project retention
+
+  Background:
+    When I set env variables:
+      """
+      SYNGRISI_TEST_MODE: true
+      SYNGRISI_AUTH: false
+      SYNGRISI_AUTO_REMOVE_CHECKS_POLL_INTERVAL_MS: 1000
+      SYNGRISI_AUTO_REMOVE_CHECKS_MIN_INTERVAL_MS: 1000
+      SYNGRISI_ENABLE_SCHEDULERS_IN_TEST_MODE: true
+      """
+    Given I start Server
+    When I create via http test user
+
+    Given I stop the Syngrisi server
+    When I wait 5 seconds
+    When I set env variables:
+      """
+      SYNGRISI_TEST_MODE: true
+      SYNGRISI_AUTH: true
+      SYNGRISI_AUTO_REMOVE_CHECKS_POLL_INTERVAL_MS: 1000
+      SYNGRISI_AUTO_REMOVE_CHECKS_MIN_INTERVAL_MS: 1000
+      SYNGRISI_ENABLE_SCHEDULERS_IN_TEST_MODE: true
+      """
+    Given I start Server
+
+    # create user
+    When I login via http with user:"Test" password "123456aA-"
+    When I generate via http API key for the User
+    When I set the API key in config
+    When I start Driver
+
+  @smoke
+  Scenario: Per-project retention removes old checks only for the opted-in project
+    When I create "1" tests with:
+      """
+      testName: RetentionTestA
+      project: RetentionProjectA
+      checks:
+        - checkName: projA_old
+          filePath: files/A.png
+      """
+    When I update via http check with params:
+      """
+      createdDate: <currentDate-10>
+      """
+
+    When I create "1" tests with:
+      """
+      testName: RetentionTestB
+      project: RetentionProjectB
+      checks:
+        - checkName: projB_old
+          filePath: files/A.png
+      """
+    When I update via http check with params:
+      """
+      createdDate: <currentDate-10>
+      """
+
+    Then I expect via http that "projA_old" check exist exactly "1" times
+    Then I expect via http that "projB_old" check exist exactly "1" times
+
+    # Only project A opts in to a short retention window; project B keeps default (no retention).
+    Given the project "RetentionProjectA" has retention enabled "true" days "1"
+
+    # Enable the instance-wide scheduler tick (large "days" so the global sweep itself
+    # does not remove either check — only the per-project retention loop should).
+    When I update via http setting "auto_remove_old_checks" with params:
+      """
+      value:
+        days: 3650
+        lastRunAt: null
+      enabled: true
+      """
+
+    Then I wait up to 60 seconds via http that "projA_old" check exist exactly "0" times
+    Then I expect via http that "projB_old" check exist exactly "1" times

--- a/packages/syngrisi/e2e/features/CHECKS_HANDLING/baseline_promotion.feature
+++ b/packages/syngrisi/e2e/features/CHECKS_HANDLING/baseline_promotion.feature
@@ -1,0 +1,44 @@
+@fast-server
+Feature: Promote baselines from a feature branch to the project's main branch
+    Promoting copies all ACCEPTED baselines of a project on a source branch to a target
+    branch (typically the project's `mainBranch`), so a feature branch's approved baselines
+    become the main-branch baselines. After promotion, the main branch has its own accepted
+    baseline for the same ident (not merely a read-time fallback to another branch).
+
+    Background:
+        Given I clear database
+
+    @smoke
+    Scenario: Promoting a feature branch's accepted baseline makes main pass against it directly
+        Given I create "1" tests with:
+            """
+            testName: FeatureBranchTest
+            project: PromotionApp
+            branch: feature-x
+            checks:
+              - checkName: PromoteCheck
+                filePath: files/A.png
+            """
+        When I accept via http the 1st check with name "PromoteCheck"
+        And the project "PromotionApp" has main branch "main"
+
+        And I promote via http baselines for project "PromotionApp" from branch "feature-x" to branch "main"
+
+        Given I create "1" tests with:
+            """
+            testName: MainBranchTest
+            project: PromotionApp
+            branch: main
+            checks:
+              - checkName: PromoteCheck
+                filePath: files/A.png
+            """
+
+        Then I expect via http 1st check filtered as "name=PromoteCheck" matched:
+            """
+            name: PromoteCheck
+            branch: main
+            status: [passed]
+            """
+
+        And I expect via http that "PromoteCheck" "baseline" exist exactly "2" times

--- a/packages/syngrisi/e2e/steps/domain/branch-baseline.steps.ts
+++ b/packages/syngrisi/e2e/steps/domain/branch-baseline.steps.ts
@@ -1,4 +1,4 @@
-import { Given, Then } from '@fixtures';
+import { Given, Then, When } from '@fixtures';
 import type { AppServerFixture } from '@fixtures';
 import type { TestStore } from '@fixtures';
 import { requestWithSession } from '@utils/http-client';
@@ -35,5 +35,27 @@ Then(
     async ({ appServer, testData }: { appServer: AppServerFixture; testData: TestStore }, project: string, mainBranch: string) => {
         const app = await getAppByName(appServer, testData, project);
         expect(app.mainBranch).toBe(mainBranch);
+    },
+);
+
+// Promotes all ACCEPTED baselines of a project on a source branch to a target branch
+// (POST /v1/baselines/promote), so a feature branch's approved baselines become the
+// target branch's baselines. See baseline.service.ts promoteBaselines.
+When(
+    'I promote via http baselines for project {string} from branch {string} to branch {string}',
+    async (
+        { appServer, testData }: { appServer: AppServerFixture; testData: TestStore },
+        project: string,
+        fromBranch: string,
+        toBranch: string,
+    ) => {
+        const app = await getAppByName(appServer, testData, project);
+        const id = app._id || app.id;
+        const promoteUri = `${appServer.baseURL}/v1/baselines/promote`;
+        const resp = await requestWithSession(promoteUri, testData, appServer, {
+            method: 'POST',
+            json: { app: id, fromBranch, toBranch },
+        });
+        expect(resp.raw?.statusCode).toBe(200);
     },
 );

--- a/packages/syngrisi/e2e/steps/domain/branch-baseline.steps.ts
+++ b/packages/syngrisi/e2e/steps/domain/branch-baseline.steps.ts
@@ -37,3 +37,25 @@ Then(
         expect(app.mainBranch).toBe(mainBranch);
     },
 );
+
+// Set the project's per-project retention (auto-delete old checks) via the same
+// PATCH /v1/app/:id/triage-policy endpoint (retentionEnabled / retentionDays fields — see
+// AppTriagePolicy.schema.ts / app.controller.ts).
+Given(
+    'the project {string} has retention enabled {string} days {string}',
+    async (
+        { appServer, testData }: { appServer: AppServerFixture; testData: TestStore },
+        project: string,
+        enabled: string,
+        days: string,
+    ) => {
+        const app = await getAppByName(appServer, testData, project);
+        const id = app._id || app.id;
+        const patchUri = `${appServer.baseURL}/v1/app/${id}/triage-policy`;
+        const resp = await requestWithSession(patchUri, testData, appServer, {
+            method: 'PATCH',
+            json: { retentionEnabled: enabled === 'true', retentionDays: parseInt(days, 10) },
+        });
+        expect(resp.raw?.statusCode).toBe(200);
+    },
+);

--- a/packages/syngrisi/src/server/controllers/app.controller.ts
+++ b/packages/syngrisi/src/server/controllers/app.controller.ts
@@ -70,6 +70,8 @@ const updateTriagePolicy = catchAsync(async (req: Request, res: Response) => {
     if (req.body.changeSimGate !== undefined) set.changeSimGate = Number(req.body.changeSimGate);
     if (req.body.mainBranch !== undefined) set.mainBranch = req.body.mainBranch;
     if (req.body.branchFallbackEnabled !== undefined) set.branchFallbackEnabled = req.body.branchFallbackEnabled;
+    if (req.body.retentionDays !== undefined) set.retentionDays = Number(req.body.retentionDays);
+    if (req.body.retentionEnabled !== undefined) set.retentionEnabled = req.body.retentionEnabled;
     const app = await App.findByIdAndUpdate(id, { $set: set }, { new: true }).exec();
     if (!app) {
         res.status(HttpStatus.NOT_FOUND).json({ error: 'App not found' });

--- a/packages/syngrisi/src/server/controllers/baseline.controller.ts
+++ b/packages/syngrisi/src/server/controllers/baseline.controller.ts
@@ -8,8 +8,9 @@ import { Response } from "express";
 
 import { ApiError } from '@utils';
 import { ExtRequest } from '@types';
-import { getUsageCountsBySnapshotIds, remove as removeBaseline } from '@services/baseline.service';
+import { getUsageCountsBySnapshotIds, remove as removeBaseline, promoteBaselines, promoteRun } from '@services/baseline.service';
 import { getHistory, getHistorySummary, BaselineHistoryIdent } from '@services/baseline-history.service';
+import { App } from '@models';
 
 const get = catchAsync(async (req: ExtRequest, res: Response) => {
     const filter = typeof req.query.filter === 'string'
@@ -95,6 +96,32 @@ const getBaselineHistorySummary = catchAsync(async (req: ExtRequest, res: Respon
     res.send(result);
 });
 
+const promote = catchAsync(async (req: ExtRequest, res: Response) => {
+    if (!req.user) throw new Error("req.user is empty");
+    const { runId, app: appId, fromBranch, toBranch } = req.body;
+
+    if (runId) {
+        const result = await promoteRun({ runId, user: req.user });
+        res.send(result);
+        return;
+    }
+
+    if (!appId || !fromBranch) {
+        throw new ApiError(HttpStatus.BAD_REQUEST, "either 'runId' or both 'app' and 'fromBranch' must be provided");
+    }
+
+    let resolvedToBranch = toBranch;
+    if (!resolvedToBranch) {
+        const app = await App.findById(appId).exec();
+        if (!app) throw new ApiError(HttpStatus.NOT_FOUND, `app not found, id: '${appId}'`);
+        if (!app.mainBranch) throw new ApiError(HttpStatus.BAD_REQUEST, "project has no main branch configured");
+        resolvedToBranch = app.mainBranch;
+    }
+
+    const result = await promoteBaselines({ appId, fromBranch, toBranch: resolvedToBranch, user: req.user });
+    res.send(result);
+});
+
 export {
     get,
     put,
@@ -102,4 +129,5 @@ export {
     getDomSnapshot,
     getBaselineHistory,
     getBaselineHistorySummary,
+    promote,
 };

--- a/packages/syngrisi/src/server/lib/schedulers/autoCleanupSchedulers.ts
+++ b/packages/syngrisi/src/server/lib/schedulers/autoCleanupSchedulers.ts
@@ -1,6 +1,7 @@
 import { AutoCleanupScheduler } from './autoCleanupScheduler';
 import { handleOldChecksTask, removeOldLogsTask } from '@/tasks/core';
 import { LoggerOutputWriter } from '@/tasks/lib/output-writer';
+import { App } from '@models';
 
 
 const checksScheduler = new AutoCleanupScheduler({
@@ -10,6 +11,13 @@ const checksScheduler = new AutoCleanupScheduler({
     runTask: async (days: number) => {
         const output = new LoggerOutputWriter('auto_old_checks');
         await handleOldChecksTask({ days, remove: true }, output);
+
+        // Per-project retention: additionally clean up checks for projects that opted in
+        // to their own retention window, independent of the instance-wide setting above.
+        const apps = await App.find({ retentionEnabled: true, retentionDays: { $gt: 0 } }).lean();
+        for (const a of apps) {
+            await handleOldChecksTask({ days: a.retentionDays as number, remove: true, appId: String(a._id) }, output);
+        }
     },
 });
 

--- a/packages/syngrisi/src/server/models/App.model.ts
+++ b/packages/syngrisi/src/server/models/App.model.ts
@@ -31,6 +31,8 @@ export interface AppDocument extends Document {
     changeSimGate?: number; // cosine cutoff for "same change at other resolutions" (per-project)
     mainBranch?: string; // read-time baseline fallback: branch whose accepted baselines cover every other branch; empty = disabled
     branchFallbackEnabled?: boolean; // explicit opt-in for the mainBranch fallback; default false
+    retentionDays?: number; // per-project auto-delete: remove checks older than this many days
+    retentionEnabled?: boolean; // explicit opt-in for per-project retention; default false
 }
 
 const AppSchema: Schema<AppDocument> = new Schema({
@@ -104,6 +106,13 @@ const AppSchema: Schema<AppDocument> = new Schema({
         type: String,
     },
     branchFallbackEnabled: {
+        type: Boolean,
+        default: false,
+    },
+    retentionDays: {
+        type: Number,
+    },
+    retentionEnabled: {
         type: Boolean,
         default: false,
     },

--- a/packages/syngrisi/src/server/routes/v1/baselines.route.ts
+++ b/packages/syngrisi/src/server/routes/v1/baselines.route.ts
@@ -10,6 +10,8 @@ import {
     BaselineHistoryItemSchema,
     HistorySummaryBodySchema,
     HistorySummaryResponseSchema,
+    BaselinePromoteSchema,
+    BaselinePromoteResponseSchema,
 } from '@schemas/Baseline.schema';
 import { createApiEmptyResponse, createApiResponse, createPaginatedApiResponse } from '@api-docs/openAPIResponseBuilders';
 import { ApiErrorSchema } from '@schemas/common/ApiError.schema';
@@ -135,6 +137,22 @@ router.post(
     ensureLoggedIn(),
     validateRequest(createRequestBodySchema(HistorySummaryBodySchema), 'post, /v1/baselines/history-summary'),
     baselineController.getBaselineHistorySummary as Midleware
+);
+
+registry.registerPath({
+    method: 'post',
+    path: '/v1/baselines/promote',
+    summary: "Promote all ACCEPTED baselines from a source branch to a target branch (typically the project's mainBranch)",
+    tags: ['Baselines'],
+    request: { body: createRequestOpenApiBodySchema(BaselinePromoteSchema) },
+    responses: createApiResponse(BaselinePromoteResponseSchema, 'Success'),
+});
+
+router.post(
+    '/promote',
+    ensureLoggedInOrApiKey(),
+    validateRequest(createRequestBodySchema(BaselinePromoteSchema), 'post, /v1/baselines/promote'),
+    baselineController.promote as Midleware
 );
 
 export default router;

--- a/packages/syngrisi/src/server/schemas/AppTriagePolicy.schema.ts
+++ b/packages/syngrisi/src/server/schemas/AppTriagePolicy.schema.ts
@@ -75,6 +75,10 @@ export const AppTriagePolicyUpdateSchema = z.object({
     mainBranch: z.string().max(255).optional(),
     // Explicit opt-in for the mainBranch fallback above; default false.
     branchFallbackEnabled: z.boolean().optional(),
+    // Per-project auto-delete: remove checks older than this many days.
+    retentionDays: z.number().int().min(0).max(3650).optional(),
+    // Explicit opt-in for the per-project retention above; default false.
+    retentionEnabled: z.boolean().optional(),
 }).strict();
 
 export type AppTriagePolicyUpdateType = z.infer<typeof AppTriagePolicyUpdateSchema>;

--- a/packages/syngrisi/src/server/schemas/Baseline.schema.ts
+++ b/packages/syngrisi/src/server/schemas/Baseline.schema.ts
@@ -181,6 +181,35 @@ const HistorySummaryResponseSchema = z.object({
     cached: z.boolean().optional(),
 });
 
+// Promote all ACCEPTED baselines from a source branch to a target branch (typically the
+// project's mainBranch). Accepts EITHER a runId (resolves app/fromBranch/toBranch from the
+// run) OR an explicit app + fromBranch (+ optional toBranch, defaults to the app's mainBranch).
+// Both shapes are optional here; the controller validates which combination is actually usable.
+const BaselinePromoteSchema = z.object({
+    runId: commonValidations.id.optional().openapi({
+        description: 'Run identifier - promotes all branches used by the run to the app mainBranch',
+        example: '6651dd45b9c3e1e0b8c1ce27',
+    }),
+    app: commonValidations.id.optional().openapi({
+        description: 'Application identifier',
+        example: '6651dd45b9c3e1e0b8c1ce26',
+    }),
+    fromBranch: z.string().min(1).optional().openapi({
+        description: 'Source branch whose accepted baselines are promoted',
+        example: 'feature-x',
+    }),
+    toBranch: z.string().min(1).optional().openapi({
+        description: 'Target branch to promote baselines to (defaults to the app mainBranch)',
+        example: 'main',
+    }),
+});
+
+const BaselinePromoteResponseSchema = z.object({
+    promoted: z.number(),
+    fromBranch: z.string(),
+    toBranch: z.string(),
+});
+
 export {
     BaselineGetSchema,
     BaselinePutSchema,
@@ -190,4 +219,6 @@ export {
     BaselineHistoryItemSchema,
     HistorySummaryBodySchema,
     HistorySummaryResponseSchema,
+    BaselinePromoteSchema,
+    BaselinePromoteResponseSchema,
 };

--- a/packages/syngrisi/src/server/services/baseline.service.ts
+++ b/packages/syngrisi/src/server/services/baseline.service.ts
@@ -1,4 +1,4 @@
-import { Snapshot, Check, App, Baseline } from '@models';
+import { Snapshot, Check, App, Baseline, Run } from '@models';
 import { buildIdentObject, prettyCheckParams, ApiError } from '@utils';
 import log from "@logger";
 import { LogOpts } from '@types';
@@ -207,3 +207,110 @@ export const getUsageCountsBySnapshotIds = async (snapshootIds: Array<Types.Obje
 
     return buildUsageCountMap(usageRows);
 };
+
+export type PromoteBaselinesParams = {
+    appId: string;
+    fromBranch: string;
+    toBranch: string;
+    user: { _id: unknown; username: string };
+};
+
+export type PromoteBaselinesResult = { promoted: number, fromBranch: string, toBranch: string };
+
+/**
+ * Promote all ACCEPTED baselines of an app on `fromBranch` to `toBranch` (typically the
+ * project's mainBranch), so a feature branch's approved baselines become the main-branch
+ * baselines. Mirrors the upsert shape of createNewBaseline (check.service.ts), but clones
+ * the source baseline's snapshootId onto a different branch instead of creating a fresh
+ * snapshot. Since getAcceptedBaseline resolves the accepted baseline by sorting
+ * createdDate desc, the newly-created (or refreshed) baseline naturally becomes the active
+ * one for toBranch without needing to explicitly demote any prior accepted baseline there.
+ */
+export async function promoteBaselines(params: PromoteBaselinesParams): Promise<PromoteBaselinesResult> {
+    const { appId, fromBranch, toBranch, user } = params;
+    const logOpts: LogOpts = {
+        scope: 'promoteBaselines',
+        itemType: 'baseline',
+        user: user?.username,
+        msgType: 'PROMOTE',
+    };
+
+    const sourceBaselines = await Baseline.find({ app: appId, branch: fromBranch, markedAs: 'accepted' } as any).exec();
+    log.info(`promoting ${sourceBaselines.length} accepted baseline(s) for app: '${appId}' from branch: '${fromBranch}' to branch: '${toBranch}'`, logOpts);
+
+    let promoted = 0;
+    for (const source of sourceBaselines) {
+        const identFields = buildIdentObject({
+            name: source.name,
+            viewport: source.viewport,
+            browserName: source.browserName,
+            os: source.os,
+            app: source.app.toString(),
+            branch: toBranch,
+        });
+
+        const filter = { ...identFields, snapshootId: source.snapshootId };
+
+        const baselineParams: Record<string, unknown> = { ...identFields };
+        if (source.ignoreRegions) baselineParams.ignoreRegions = source.ignoreRegions;
+        if (source.boundRegions) baselineParams.boundRegions = source.boundRegions;
+        if (source.matchType) baselineParams.matchType = source.matchType;
+        if (typeof source.toleranceThreshold === 'number') baselineParams.toleranceThreshold = source.toleranceThreshold;
+
+        const update = {
+            $setOnInsert: {
+                ...baselineParams,
+                snapshootId: source.snapshootId,
+                createdDate: new Date(),
+            },
+            $set: {
+                markedAs: 'accepted',
+                markedById: user._id,
+                markedByUsername: user.username,
+                lastMarkedDate: new Date(),
+            },
+        };
+
+        await Baseline.findOneAndUpdate(filter as any, update, { new: true, upsert: true }).exec();
+        promoted += 1;
+    }
+
+    return { promoted, fromBranch, toBranch };
+}
+
+export type PromoteRunParams = { runId: string, user: { _id: unknown; username: string } };
+
+/**
+ * Promote the baselines of a run's app/branch(es) to the app's configured mainBranch.
+ * Resolves the run's app and the distinct branch(es) used by the run's checks, then
+ * promotes each distinct branch (skipping the mainBranch itself) to the mainBranch.
+ */
+export async function promoteRun(params: PromoteRunParams): Promise<PromoteBaselinesResult> {
+    const { runId, user } = params;
+
+    const run = await Run.findById(runId).exec();
+    if (!run) {
+        throw new ApiError(HttpStatus.NOT_FOUND, `cannot promote baselines, run not found, id: '${runId}'`);
+    }
+
+    const app = await App.findById(run.app).exec();
+    if (!app) {
+        throw new ApiError(HttpStatus.NOT_FOUND, `cannot promote baselines, app not found for run: '${runId}'`);
+    }
+    if (!app.mainBranch) {
+        throw new ApiError(HttpStatus.BAD_REQUEST, "project has no main branch configured");
+    }
+    const toBranch = app.mainBranch;
+
+    const branches: string[] = await Check.distinct('branch', { run: runId } as any);
+
+    let promoted = 0;
+    for (const fromBranch of branches) {
+        if (!fromBranch || fromBranch === toBranch) continue;
+        // eslint-disable-next-line no-await-in-loop
+        const result = await promoteBaselines({ appId: app.id, fromBranch, toBranch, user });
+        promoted += result.promoted;
+    }
+
+    return { promoted, fromBranch: branches.join(','), toBranch };
+}

--- a/packages/syngrisi/src/tasks/core/handle-old-checks.task.ts
+++ b/packages/syngrisi/src/tasks/core/handle-old-checks.task.ts
@@ -124,6 +124,7 @@ async function deleteFilesWithLimit(files: string[], limit: number) {
 export interface HandleOldChecksOptions {
     days: number;
     remove: boolean;
+    appId?: string; // when set, scopes the cleanup to a single project (per-project retention)
 }
 
 /**
@@ -171,6 +172,9 @@ export async function handleOldChecksTask(
         output.write('STAGE #1 Calculate common stats');
 
         const trashHoldDate = subDays(new Date(), options.days);
+        // When appId is set, every Check-match filter below is additionally scoped to that
+        // project (per-project retention). Undefined appId → instance-wide behavior, unchanged.
+        const appMatch: Record<string, unknown> = options.appId ? { app: options.appId } : {};
 
         output.write('> count all checks');
         const allChecksCountBefore = await Check.countDocuments().exec();
@@ -180,12 +184,12 @@ export async function handleOldChecksTask(
         const allFilesBefore = await countPngFiles(config.defaultImagesPath);
 
         output.write('> count old checks');
-        const oldChecksCount = await Check.countDocuments({ createdDate: { $lt: trashHoldDate } }).exec();
+        const oldChecksCount = await Check.countDocuments({ ...appMatch, createdDate: { $lt: trashHoldDate } }).exec();
 
         output.write('>>> collect all baselineId snapshot IDs from old Checks ');
         // Use aggregation to avoid 16MB distinct limit
         const baselineIdResults = await Check.aggregate([
-            { $match: { createdDate: { $lt: trashHoldDate }, baselineId: { $ne: null } } },
+            { $match: { ...appMatch, createdDate: { $lt: trashHoldDate }, baselineId: { $ne: null } } },
             { $group: { _id: '$baselineId' } },
             { $project: { _id: 1 } }
         ]).exec();
@@ -195,7 +199,7 @@ export async function handleOldChecksTask(
 
         output.write('>>> collect all actualSnapshotId from old Checks ');
         const actualSnapshotIdResults = await Check.aggregate([
-            { $match: { createdDate: { $lt: trashHoldDate }, actualSnapshotId: { $ne: null } } },
+            { $match: { ...appMatch, createdDate: { $lt: trashHoldDate }, actualSnapshotId: { $ne: null } } },
             { $group: { _id: '$actualSnapshotId' } },
             { $project: { _id: 1 } }
         ]).exec();
@@ -205,7 +209,7 @@ export async function handleOldChecksTask(
 
         output.write('>>> collect all diffId snapshot IDs from old Checks ');
         const diffIdResults = await Check.aggregate([
-            { $match: { createdDate: { $lt: trashHoldDate }, diffId: { $ne: null } } },
+            { $match: { ...appMatch, createdDate: { $lt: trashHoldDate }, diffId: { $ne: null } } },
             { $group: { _id: '$diffId' } },
             { $project: { _id: 1 } }
         ]).exec();
@@ -299,7 +303,7 @@ export async function handleOldChecksTask(
             let collectedBaselineSnapshotIds: string[] = [];
             try {
                 output.write('> collect current snapshot references');
-                collectedCheckSnapshotIds = await collectCheckSnapshotIds({ createdDate: { $gte: trashHoldDate } });
+                collectedCheckSnapshotIds = await collectCheckSnapshotIds({ ...appMatch, createdDate: { $gte: trashHoldDate } });
                 collectedBaselineSnapshotIds = await collectBaselineSnapshotIds();
                 output.write('>>> snapshot references collected');
             } catch (collectError) {
@@ -310,8 +314,8 @@ export async function handleOldChecksTask(
             try {
                 output.write('> remove checks');
                 const checkRemovingResult = useTransactions && session
-                    ? await Check.deleteMany({ createdDate: { $lt: trashHoldDate } }, { session })
-                    : await Check.deleteMany({ createdDate: { $lt: trashHoldDate } });
+                    ? await Check.deleteMany({ ...appMatch, createdDate: { $lt: trashHoldDate } }, { session })
+                    : await Check.deleteMany({ ...appMatch, createdDate: { $lt: trashHoldDate } });
                 output.write(`>>> removed: '${checkRemovingResult.deletedCount}'`);
 
                 output.write('> remove snapshots');

--- a/packages/syngrisi/src/ui-app/admin/components/Settings/PerProjectSettings.tsx
+++ b/packages/syngrisi/src/ui-app/admin/components/Settings/PerProjectSettings.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import {
-    Paper, Select, Switch, TextInput, Button, Group, Text, Title,
+    Paper, Select, Switch, TextInput, NumberInput, Button, Group, Text, Title,
 } from '@mantine/core';
 import { useQuery } from '@tanstack/react-query';
 import { GenericService } from '@shared/services';
@@ -17,12 +17,16 @@ export function PerProjectSettings() {
 
     const [branchFallbackEnabled, setBranchFallbackEnabled] = useState(false);
     const [mainBranch, setMainBranch] = useState('');
+    const [retentionEnabled, setRetentionEnabled] = useState(false);
+    const [retentionDays, setRetentionDays] = useState<number>(90);
     const [saving, setSaving] = useState(false);
 
     useEffect(() => {
         if (!selected) return;
         setBranchFallbackEnabled(selected.branchFallbackEnabled === true);
         setMainBranch(typeof selected.mainBranch === 'string' ? selected.mainBranch : '');
+        setRetentionEnabled(selected.retentionEnabled === true);
+        setRetentionDays(typeof selected.retentionDays === 'number' ? selected.retentionDays : 90);
     }, [selected]);
 
     const save = async () => {
@@ -32,6 +36,8 @@ export function PerProjectSettings() {
             const resp = await http.patch(`${config.baseUri}/v1/app/${appId}/triage-policy`, {
                 mainBranch: mainBranch.trim(),
                 branchFallbackEnabled,
+                retentionEnabled,
+                retentionDays,
             }, {}, 'PerProjectSettings.save');
             if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
             successMsg({ message: 'Project settings saved' });
@@ -74,6 +80,26 @@ export function PerProjectSettings() {
                         onChange={(e) => setMainBranch(e.currentTarget.value)}
                         data-test="settings-main-branch"
                         disabled={!branchFallbackEnabled}
+                        w={260}
+                        mb="md"
+                    />
+                    <Switch
+                        label="Enable retention (auto-delete old checks)"
+                        description="Older checks in this project are deleted automatically; baselines are never removed."
+                        checked={retentionEnabled}
+                        onChange={(e) => setRetentionEnabled(e.currentTarget.checked)}
+                        data-test="settings-retention-enabled"
+                        mb="md"
+                        styles={{ description: { maxWidth: 420 } }}
+                    />
+                    <NumberInput
+                        label="Keep checks for (days)"
+                        description="Checks older than this many days are removed automatically; baselines are never removed."
+                        value={retentionDays}
+                        onChange={(v) => setRetentionDays(typeof v === 'number' ? v : 90)}
+                        data-test="settings-retention-days"
+                        disabled={!retentionEnabled}
+                        min={1}
                         w={260}
                         mb="md"
                     />

--- a/packages/syngrisi/src/ui-app/index2/components/Navbar/Items/PromoteBaselinesModalAsk.tsx
+++ b/packages/syngrisi/src/ui-app/index2/components/Navbar/Items/PromoteBaselinesModalAsk.tsx
@@ -1,0 +1,59 @@
+/* eslint-disable no-underscore-dangle,react/jsx-one-expression-per-line */
+import { Button, Group, Modal, Text } from '@mantine/core';
+import * as React from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { errorMsg, successMsg } from '@shared/utils/utils';
+import { log } from '@shared/utils/Logger';
+import { RunsService } from '@shared/services';
+
+interface Props {
+    opened: boolean,
+    setOpened: any,
+    item: any,
+}
+
+export default function PromoteBaselinesModalAsk({ opened, setOpened, item }: Props) {
+    const promotingMutation = useMutation(
+        {
+            mutationFn: (data: { runId: string }) => RunsService.promoteBaselines(data),
+            onSuccess: async (result: any) => {
+                successMsg({ message: `Promoted ${result?.promoted ?? 0} baseline(s) to ${result?.toBranch ?? 'the main branch'}` });
+            },
+            onError: (e: any) => {
+                errorMsg({ error: e?.message || 'Cannot promote baselines' });
+                log.error(e);
+            },
+        },
+    );
+    const handlePromoteButtonClick = async () => {
+        await promotingMutation.mutateAsync({ runId: item._id });
+        setOpened(false);
+    };
+    return (
+        <Modal
+            data-test="promote-baselines-modal"
+            opened={opened}
+            onClose={() => setOpened(false)}
+            title="Promote baselines to main?"
+        >
+            <Text size="sm">
+                This will promote all accepted baselines of this run&apos;s branch(es) to the project&apos;s main
+                branch, so they become the main-branch baselines.
+            </Text>
+            <Group justify="flex-end" mt="md">
+                <Button
+                    data-test="run-promote-confirm"
+                    loading={promotingMutation.isPending}
+                    onClick={
+                        async () => {
+                            await handlePromoteButtonClick();
+                        }
+                    }
+                >
+                    Promote
+                </Button>
+                <Button variant="outline" onClick={() => setOpened(false)}>Cancel</Button>
+            </Group>
+        </Modal>
+    );
+}

--- a/packages/syngrisi/src/ui-app/index2/components/Navbar/Items/RemoveItemPopover.tsx
+++ b/packages/syngrisi/src/ui-app/index2/components/Navbar/Items/RemoveItemPopover.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ActionIcon, Button, Group, Popover } from '@mantine/core';
+import { ActionIcon, Button, Stack, Popover } from '@mantine/core';
 import { IconDotsVertical } from '@tabler/icons-react';
 
 interface Props {
@@ -8,6 +8,10 @@ interface Props {
     handleRemoveItemClick: any
     type: string
     testAttr?: string
+    // Optional extra action rendered above the Remove button (e.g. "Promote baselines to main"
+    // for runs). Kept optional so this popover stays reusable for other item types (e.g. Suite)
+    // that don't need it.
+    onPromoteClick?: any
 }
 
 export function RemoveItemPopover(
@@ -17,6 +21,7 @@ export function RemoveItemPopover(
         handleRemoveItemClick,
         type,
         testAttr = 'remove-popover-action-icon',
+        onPromoteClick,
 
     }: Props,
 ) {
@@ -36,7 +41,22 @@ export function RemoveItemPopover(
                 </ActionIcon>
             </Popover.Target>
             <Popover.Dropdown p={8}>
-                <Group justify="center">
+                <Stack gap={4} align="stretch">
+                    {onPromoteClick && (
+                        <Button
+                            data-test="run-promote-baselines"
+                            variant="light"
+                            onClick={
+                                (e: any) => {
+                                    e.stopPropagation();
+                                    e.preventDefault();
+                                    onPromoteClick();
+                                }
+                            }
+                        >
+                            Promote baselines to main
+                        </Button>
+                    )}
                     <Button
                         data-item={`${testAttr}_confirm`}
                         onClick={
@@ -51,7 +71,7 @@ export function RemoveItemPopover(
                         {' '}
                         {type}
                     </Button>
-                </Group>
+                </Stack>
             </Popover.Dropdown>
         </Popover>
     );

--- a/packages/syngrisi/src/ui-app/index2/components/Navbar/Items/RunItem.tsx
+++ b/packages/syngrisi/src/ui-app/index2/components/Navbar/Items/RunItem.tsx
@@ -5,6 +5,7 @@ import * as dateFns from 'date-fns';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDisclosure } from '@mantine/hooks';
 import RemoveItemModalAsk from '@index/components/Navbar/Items/RemoveItemModalAsk';
+import PromoteBaselinesModalAsk from '@index/components/Navbar/Items/PromoteBaselinesModalAsk';
 import { StatusesRing } from '@shared/components/Tests/StatusesRing';
 import { RemoveItemPopover } from '@index/components/Navbar/Items/RemoveItemPopover';
 
@@ -32,10 +33,16 @@ export const RunItem = React.memo(function RunItem(
     }: Props,
 ) {
     const [modalOpen, setModalOpen] = useState(false);
+    const [promoteModalOpen, setPromoteModalOpen] = useState(false);
     const [opened, { toggle, close }] = useDisclosure(false);
 
     const handleRemoveItemClick = () => {
         setModalOpen(true);
+        close();
+    };
+
+    const handlePromoteItemClick = () => {
+        setPromoteModalOpen(true);
         close();
     };
 
@@ -115,6 +122,7 @@ export const RunItem = React.memo(function RunItem(
                         }
                         <RemoveItemPopover
                             handleRemoveItemClick={handleRemoveItemClick}
+                            onPromoteClick={handlePromoteItemClick}
                             type={type}
                             opened={opened}
                             toggle={toggle}
@@ -128,6 +136,11 @@ export const RunItem = React.memo(function RunItem(
                 infinityQuery={infinityQuery}
                 item={item}
                 type={type}
+            />
+            <PromoteBaselinesModalAsk
+                opened={promoteModalOpen}
+                setOpened={setPromoteModalOpen}
+                item={item}
             />
         </>
     );

--- a/packages/syngrisi/src/ui-app/shared/services/runs.service.ts
+++ b/packages/syngrisi/src/ui-app/shared/services/runs.service.ts
@@ -11,4 +11,14 @@ export const RunsService = {
         );
         return resp.json();
     },
+
+    async promoteBaselines({ runId }: { runId: string }) {
+        const resp = await http.post(
+            `${config.baseUri}/v1/baselines/promote`,
+            { runId },
+            {},
+            'RunsService.promoteBaselines'
+        );
+        return resp.json();
+    },
 };


### PR DESCRIPTION
## Summary

Three roadmap features, each with e2e coverage.

### 1. Baseline promotion on merge
Promote a feature branch's **accepted** baselines to the project's main branch.
- `POST /v1/baselines/promote` — accepts `{runId}` or `{app, fromBranch, toBranch?}`; CI-callable with an API key (`ensureLoggedInOrApiKey`), Zod-validated.
- **UI**: "Promote baselines to main" action in the run kebab menu (`data-test="run-promote-baselines"` → confirm).
- Service: `promoteBaselines()` / `promoteRun()` in `baseline.service.ts`, mirroring the `createNewBaseline` upsert.

### 2. Per-project retention
Auto-delete old checks per project.
- New `App` fields `retentionEnabled` / `retentionDays` (default off), persisted via `PATCH /v1/app/:id/triage-policy`.
- **UI**: Admin → Settings → **Project settings** tab (Switch + NumberInput).
- The cleanup scheduler runs per-project retention (`App.find({retentionEnabled, retentionDays>0})` → `handleOldChecksTask({days, remove, appId})`) on top of the instance-wide policy.

### 3. Official GitHub Action + CI recipe
- `.github/actions/syngrisi-status` composite action: polls `/v1/tests?filter={"run":...}` and gates the job on Passed/Failed/New.
- Example reusable workflow + `docs/CI.md` guide, linked from the README.

## Tests
- New e2e: `baseline_promotion.feature`, `per_project_retention.feature` (both green).
- Regression: AP + INTEGRATION + CHECKS_HANDLING (74 passed), CP serial (148 passed).
- GitHub Action poll-script verified live against a local HTTP stub (Passed→exit0, Failed→exit1, New-gated correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)