### PR TITLE
test+docs: UI e2e + docs for baseline promotion & per-project retention

### DIFF
--- a/.changeset/promotion-retention-tests-docs.md
+++ b/.changeset/promotion-retention-tests-docs.md
@@ -1,0 +1,8 @@
+---
+"@syngrisi/syngrisi": patch
+---
+
+Add UI e2e coverage and documentation for baseline promotion and per-project retention.
+
+- E2E: run-kebab promotion flow (promote → confirm → main gets its own accepted baseline) and a Project settings UI scenario that persists retention on the App document.
+- Docs: a "Promoting baselines on merge" section in `BRANCH_BASELINES.md` and a new `RETENTION.md`, both linked from the README.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ expensive, send your screenshots to someone else's servers, and lock you in.
 - 🧩 **Plugin system & rich configuration** — extend behaviour and tune everything through environment variables.
 - 🔔 **Webhooks** — check, test and run (`run.finished`) lifecycle events with secret signing.
 - 🌿 **Branch baseline fallback** _(opt-in)_ — a feature branch with no baseline of its own is compared against the project's main-branch baseline instead of starting from scratch; toggled per project under **Admin → Settings → Project settings**.
-- ⬆️ **Baseline promotion** — promote a feature branch's accepted baselines to the project's main branch in one step, from the run menu or via `POST /v1/baselines/promote` for CI.
-- 🗑️ **Per-project retention** _(opt-in)_ — auto-delete old checks per project on a configurable day window, set under **Admin → Settings → Project settings**.
+- ⬆️ **Baseline promotion** — promote a feature branch's accepted baselines to the project's main branch in one step, from the run menu or via `POST /v1/baselines/promote` for CI ([guide](packages/syngrisi/docs/BRANCH_BASELINES.md#promoting-baselines-on-merge)).
+- 🗑️ **Per-project retention** _(opt-in)_ — auto-delete old checks per project on a configurable day window, set under **Admin → Settings → Project settings** ([guide](packages/syngrisi/docs/RETENTION.md)).
 - ✅ **GitHub commit status** — report a run's pass/fail state straight to the PR, with a deep link back to the grid.
 - 🐳 **Self-hosted & Docker-ready** — Express + MongoDB backend, React + Mantine UI.
 - 🤖 **MCP server** — let AI agents query runs, view diffs and accept checks from the IDE.
@@ -268,6 +268,7 @@ packages/
 - 🤖 [AI Features](packages/syngrisi/docs/AI_FEATURES.md) · [Root Cause Analysis](packages/syngrisi/docs/RCA.md)
 - 🧩 [Plugins](packages/syngrisi/docs/PLUGINS.md)
 - ⚙️ [Environment Variables](packages/syngrisi/docs/environment_variables.md)
+- 🌿 [Branch baselines & promotion](packages/syngrisi/docs/BRANCH_BASELINES.md) · [Retention](packages/syngrisi/docs/RETENTION.md)
 - 🔁 [CI / GitHub Action](packages/syngrisi/docs/CI.md)
 - 🛠️ [Development Guide](packages/syngrisi/docs/DEVELOPMENT.md) · [Release Cycle](docs-src/RELEASE_CYCLE.md)
 - 🔗 API reference: Swagger UI at `/swagger/` on a running instance.

--- a/packages/syngrisi/docs/BRANCH_BASELINES.md
+++ b/packages/syngrisi/docs/BRANCH_BASELINES.md
@@ -30,19 +30,56 @@ only affects which baseline a check is compared against at read time. This means
 
 ## Configuring the main branch
 
-Set it per project in **Admin → AI → Projects settings** (the "Branch baselines" section) via the
-"Main branch" field, or via the API:
+Set it per project in **Admin → Settings → Project settings** via the "Main branch" field (enable
+the "branch baseline fallback" switch first), or via the API:
 
 ```bash
 curl -X PATCH "$SYNGRISI_URL/v1/app/<appId>/triage-policy" \
   -H "Content-Type: application/json" \
-  -d '{"mainBranch": "main"}'
+  -d '{"mainBranch": "main", "branchFallbackEnabled": true}'
 ```
 
-Leave it empty to disable the fallback for a project.
+Leave it empty (or the switch off) to disable the fallback for a project.
+
+## Promoting baselines on merge
+
+The fallback above is a **read-time** convenience — the feature branch never gets its own baseline.
+When a feature branch is merged, you usually want its approved baselines to *become* the main
+branch's baselines, so main passes against them directly (no fallback needed) and the feature
+branch's history is preserved. That is **baseline promotion**: it copies every **accepted** baseline
+of a project on a source branch to a target branch (the project's `mainBranch` by default).
+
+Promotion is additive and idempotent — it upserts an accepted baseline for each `{name, viewport,
+browserName, os}` ident on the target branch, pointing at the same snapshot. Re-running it changes
+nothing. It only ever touches the target branch; the source branch is left as-is.
+
+### From the UI
+
+On the main page, open a run's **⋮** menu and choose **Promote baselines to main**, then confirm.
+All accepted baselines on that run's branch(es) are promoted to the project's configured main branch.
+A toast reports how many baselines were promoted.
+
+### From CI / the API
+
+Promote in a post-merge CI step so main is ready before the next run:
+
+```bash
+# Promote a whole run's branch(es) to the project's main branch
+curl -X POST "$SYNGRISI_URL/v1/baselines/promote" \
+  -H "apikey: $SYNGRISI_API_KEY" -H "Content-Type: application/json" \
+  -d '{"runId": "<runId>"}'
+
+# …or promote an explicit branch → branch for a project
+curl -X POST "$SYNGRISI_URL/v1/baselines/promote" \
+  -H "apikey: $SYNGRISI_API_KEY" -H "Content-Type: application/json" \
+  -d '{"app": "<appId>", "fromBranch": "feature-x", "toBranch": "main"}'
+```
+
+The endpoint accepts either `{runId}` (resolves the app + its branch(es) automatically) or
+`{app, fromBranch, toBranch?}` (`toBranch` defaults to the project's `mainBranch`). It responds with
+`{promoted, fromBranch, toBranch}`.
 
 ## What is out of scope (deferred)
 
-- Auto-promotion of feature-branch baselines to `main` on merge.
 - A per-check UI badge indicating "compared against main's baseline".
 - Multi-level fallback chains (only one fallback branch is supported).

--- a/packages/syngrisi/docs/RETENTION.md
+++ b/packages/syngrisi/docs/RETENTION.md
@@ -1,0 +1,50 @@
+# Per-project retention (auto-delete old checks)
+
+Over time a busy project accumulates thousands of checks that are no longer interesting once their
+run has been triaged. Per-project retention deletes old **checks** automatically on a schedule, on a
+day window you set for each project independently. It is **opt-in** and **off by default**, so
+existing projects keep every check until you enable it.
+
+## What it does (and does not) remove
+
+- **Removes**: checks in the project older than `retentionDays` days (by `createdDate`), together with
+  their now-unreferenced snapshots and image files, exactly like the instance-wide "handle old
+  checks" task — but scoped to the one project.
+- **Never removes**: baselines. Accepted references are always preserved, so a project whose checks
+  have been cleaned still compares correctly on the next run.
+
+This runs *in addition to* the instance-wide `auto_remove_old_checks` task. The instance task applies
+its own global day window to every project; per-project retention lets an individual project keep a
+**shorter** window than the instance default.
+
+## Enabling it
+
+### From the UI
+
+**Admin → Settings → Project settings**: pick the project, turn on **Enable retention (auto-delete
+old checks)**, set **Keep checks for (days)**, and Save.
+
+### From the API
+
+```bash
+curl -X PATCH "$SYNGRISI_URL/v1/app/<appId>/triage-policy" \
+  -H "Content-Type: application/json" \
+  -d '{"retentionEnabled": true, "retentionDays": 30}'
+```
+
+Set `retentionEnabled: false` (or `retentionDays: 0`) to turn it off for a project.
+
+## How the schedule works
+
+The cleanup scheduler ticks on the same interval as the instance-wide old-checks task. On each tick,
+after the global sweep, it finds every project with `retentionEnabled: true` and `retentionDays > 0`
+and removes that project's checks older than its own window. There is nothing to schedule per
+project — enabling the switch is enough.
+
+Relevant environment variables (see [environment_variables.md](environment_variables.md)):
+
+- `SYNGRISI_AUTO_REMOVE_CHECKS_POLL_INTERVAL_MS` — how often the scheduler tick runs.
+- `SYNGRISI_AUTO_REMOVE_CHECKS_MIN_INTERVAL_MS` — minimum gap between two actual sweeps.
+
+> Deletion is irreversible. Retention removes checks, not baselines, but the checks (and their diffs)
+> are gone — start with a generous window and shorten it once you are comfortable.

--- a/packages/syngrisi/e2e/features/AP/settings/project_settings_retention_ui.feature
+++ b/packages/syngrisi/e2e/features/AP/settings/project_settings_retention_ui.feature
@@ -1,0 +1,39 @@
+@fast-server
+Feature: Project settings UI — per-project retention
+    Enabling retention from Admin → Settings → Project settings must round-trip through the
+    triage-policy API and persist on the App document (retentionEnabled / retentionDays).
+
+    Background:
+        When I open the app
+        When I clear local storage
+        # a project must exist to be selectable in the Project settings tab
+        Given I create "1" tests with:
+            """
+            testName: RetentionUiTest
+            project: RetentionUiApp
+            checks:
+              - checkName: RetentionUiCheck
+                filePath: files/A.png
+            """
+
+    @smoke
+    Scenario: Enabling retention in the Project settings tab persists on the project
+        When I go to "settings" page
+        When I wait 10 seconds for the element with locator "[data-test='settings-tab-projects']" to be visible
+        When I click element with locator "[data-test='settings-tab-projects']"
+        When I wait 6 seconds for the element with locator "[data-test='project-settings-select']" to be visible
+
+        # pick the project
+        When I click element with locator "[data-test='project-settings-select']"
+        When I wait 6 seconds for the element with locator "[role='option']" to be visible
+        When I click element with locator "[role='option']"
+
+        # enable retention and set the day window
+        When I wait 3 seconds for the element with locator "[data-test='settings-retention-enabled']" to be visible
+        When I click element with locator "//label[starts-with(normalize-space(.),'Enable retention')]"
+        When I set "45" to the inputfield "[data-test='settings-retention-days']"
+        When I click element with locator "[data-test='project-settings-save']"
+
+        # success toast + persisted on the App document
+        When I wait 10 seconds for the element with locator "//*[contains(@class,'mantine-Notification-body')]//div[contains(text(),'saved')]" to be visible
+        Then the project "RetentionUiApp" retention is enabled "true" days "45"

--- a/packages/syngrisi/e2e/features/CHECKS_HANDLING/baseline_promotion.feature
+++ b/packages/syngrisi/e2e/features/CHECKS_HANDLING/baseline_promotion.feature
@@ -42,3 +42,49 @@ Feature: Promote baselines from a feature branch to the project's main branch
             """
 
         And I expect via http that "PromoteCheck" "baseline" exist exactly "2" times
+
+    Scenario: Promoting from the run kebab menu copies accepted baselines to main
+        When I open the app
+        When I clear local storage
+        Given I create "1" tests with:
+            """
+            testName: UiFeatureTest
+            project: PromotionUiApp
+            runName: feature-ui
+            branch: feature-ui
+            checks:
+              - checkName: UiPromoteCheck
+                filePath: files/A.png
+            """
+        When I accept via http the 1st check with name "UiPromoteCheck"
+        And the project "PromotionUiApp" has main branch "main"
+
+        # open the run's kebab menu and promote
+        When I go to "main" page
+        When I wait 10 seconds for the element with locator "//*[@data-test='navbar-item-name' and contains(., 'feature-ui')]" to be visible
+        When I click element with locator "[data-item-name='feature-ui'] button"
+        When I wait 6 seconds for the element with locator "[data-test='run-promote-baselines']" to be visible
+        When I click element with locator "[data-test='run-promote-baselines']"
+        When I wait 6 seconds for the element with locator "[data-test='run-promote-confirm']" to be visible
+        When I click element with locator "[data-test='run-promote-confirm']"
+
+        # success toast, and main now has its own accepted baseline for the same ident
+        When I wait 10 seconds for the element with locator "//*[contains(@class,'mantine-Notification-body')]//div[contains(text(),'Promoted')]" to be visible
+        Then I expect via http that "UiPromoteCheck" "baseline" exist exactly "2" times
+
+        # main compares directly against the promoted baseline (no fallback needed)
+        Given I create "1" tests with:
+            """
+            testName: UiMainTest
+            project: PromotionUiApp
+            branch: main
+            checks:
+              - checkName: UiPromoteCheck
+                filePath: files/A.png
+            """
+        Then I expect via http 1st check filtered as "name=UiPromoteCheck" matched:
+            """
+            name: UiPromoteCheck
+            branch: main
+            status: [passed]
+            """

--- a/packages/syngrisi/e2e/steps/domain/branch-baseline.steps.ts
+++ b/packages/syngrisi/e2e/steps/domain/branch-baseline.steps.ts
@@ -60,6 +60,22 @@ When(
     },
 );
 
+// Assert the project's persisted retention settings (used to confirm a UI Save round-tripped
+// through PATCH /v1/app/:id/triage-policy to the App document).
+Then(
+    'the project {string} retention is enabled {string} days {string}',
+    async (
+        { appServer, testData }: { appServer: AppServerFixture; testData: TestStore },
+        project: string,
+        enabled: string,
+        days: string,
+    ) => {
+        const app = await getAppByName(appServer, testData, project);
+        expect(String(app.retentionEnabled)).toBe(enabled);
+        expect(String(app.retentionDays)).toBe(days);
+    },
+);
+
 // Set the project's per-project retention (auto-delete old checks) via the same
 // PATCH /v1/app/:id/triage-policy endpoint (retentionEnabled / retentionDays fields — see
 // AppTriagePolicy.schema.ts / app.controller.ts).


### PR DESCRIPTION
Follow-up to #62 (3.14.0): UI-level e2e coverage and dedicated docs for baseline promotion and per-project retention.

## E2E
- baseline_promotion.feature — new UI scenario: run kebab → Promote baselines to main → confirm → toast, main gets its own accepted baseline (passes directly). Covers the runId promote path.
- project_settings_retention_ui.feature (new) — Project settings tab → enable retention + days → Save → toast, asserts retentionEnabled/retentionDays persisted on the App.
- New step: the project {string} retention is enabled {string} days {string}.

Local: promotion 2 + retention UI 1 + scheduler 1 green; stability --repeat-each=4 --workers=3 → 12 passed.

## Docs
- BRANCH_BASELINES.md — new Promoting baselines on merge section (UI + CI/API); fixed settings location; removed the implemented item from out-of-scope.
- RETENTION.md (new) — behavior, UI + API, scheduler, env vars.
- README bullets link both guides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)