### PR TITLE
fix: "accept" in AI-match/similar view scopes to the filtered checks (not the whole test)

### DIFF
--- a/.changeset/accept-similar-scoped.md
+++ b/.changeset/accept-similar-scoped.md
@@ -1,0 +1,10 @@
+---
+"@syngrisi/syngrisi": patch
+---
+
+Fix: accepting from the "AI match / similar" view no longer accepts the whole
+test. When the grid is filtered to a subset of checks (similar/AI-match, or a
+triage `_idIn` set), the bulk "accept tests" action now accepts only those
+displayed checks — the server-side `test.accept` takes an optional `checkIds`
+filter (`PUT /v1/tests/accept/:id` body), and the UI passes the currently
+filtered check ids. With no filter, the whole test is accepted as before.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           name: build-artifacts
           path: packages/
       # Ratchet gates: HARD-fail only when the pre-existing backlog GROWS. Green
-      # today (129 server-tsc / 232 lint / 249 ui-tsc); any new error/violation
+      # today (129 server-tsc / 226 lint / 0 ui-tsc); any new error/violation
       # breaks CI. When you burn the backlog down, lower the baseline numbers below.
       - name: Typecheck ratchet (must not exceed baseline)
         working-directory: packages/syngrisi
@@ -151,7 +151,7 @@ jobs:
       - name: Lint ratchet (must not exceed baseline)
         working-directory: packages/syngrisi
         run: |
-          LINT_BASELINE=232
+          LINT_BASELINE=226
           COUNT=$(yarn lint 2>&1 | grep -oE "[0-9]+ problems" | tail -1 | grep -oE "^[0-9]+" || echo 0)
           echo "lint problems: $COUNT (baseline $LINT_BASELINE)"
           if [ "$COUNT" -gt "$LINT_BASELINE" ]; then

--- a/packages/syngrisi/src/server/controllers/test.controller.ts
+++ b/packages/syngrisi/src/server/controllers/test.controller.ts
@@ -61,7 +61,10 @@ const accept = catchAsync(async (req: ExtRequest, res: Response) => {
     const { id } = req.params;
     if (!id) throw new ApiError(HttpStatus.BAD_REQUEST, 'Cannot accept the check - Id not found');
     if (!req.user) throw new ApiError(HttpStatus.BAD_REQUEST, 'Cannot accept the check - req.user is empty');
-    const result = await testService.accept(id, req?.user);
+    // Optional: accept only these checks of the test (the "AI match / similar"
+    // grid shows a filtered subset). Absent => accept the whole test.
+    const checkIds = Array.isArray(req.body?.checkIds) ? req.body.checkIds.map(String) : undefined;
+    const result = await testService.accept(id, req.user, checkIds);
     res.send(result);
 });
 

--- a/packages/syngrisi/src/server/routes/v1/tests.route.ts
+++ b/packages/syngrisi/src/server/routes/v1/tests.route.ts
@@ -3,7 +3,8 @@ import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
 import * as testController from '@controllers/test.controller';
 import { Midleware } from '@types';
 import { validateRequest } from '@utils/validateRequest';
-import { TestDistinctRequestFieldParamsSchema, TestGetSchema } from '@schemas/Test.schema';
+import { TestDistinctRequestFieldParamsSchema, TestGetSchema, TestAcceptBodySchema } from '@schemas/Test.schema';
+import { createRequestBodySchema } from '@schemas/utils/createRequestBodySchema';
 import { createApiResponse, createPaginatedApiResponse } from '@api-docs/openAPIResponseBuilders';
 import { ensureLoggedIn, ensureLoggedInOrApiKey } from '@middlewares/ensureLogin';
 import { RequestPaginationSchema } from '@schemas/common/RequestPagination.schema';
@@ -83,7 +84,7 @@ registry.registerPath({
 router.put(
     '/accept/:id',
     ensureLoggedIn(),
-    validateRequest(getByIdParamsSchema(), 'put, /v1/tests/accept/{id}'),
+    validateRequest(getByIdParamsSchema().merge(createRequestBodySchema(TestAcceptBodySchema.optional())), 'put, /v1/tests/accept/{id}'),
     testController.accept as Midleware
 );
 

--- a/packages/syngrisi/src/server/schemas/Test.schema.ts
+++ b/packages/syngrisi/src/server/schemas/Test.schema.ts
@@ -95,6 +95,12 @@ const TestAcceptSchema = z.object({
     id: commonValidations.id,
 });
 
+// Optional request body for PUT /v1/tests/accept/:id — when present, only these
+// checks of the test are accepted (the "AI match / similar" filtered subset).
+const TestAcceptBodySchema = z.object({
+    checkIds: z.array(commonValidations.id).optional(),
+});
+
 const validIds = [
     'suite',
     'run',
@@ -123,4 +129,4 @@ export const TestDistinctRequestFieldParamsSchema = z.object({
 
 const TestDistinctSchema = TestGetSchema;
 
-export { TestGetSchema, TestAcceptSchema, TestDistinctSchema };
+export { TestGetSchema, TestAcceptSchema, TestAcceptBodySchema, TestDistinctSchema };

--- a/packages/syngrisi/src/server/services/__tests__/test.service.test.ts
+++ b/packages/syngrisi/src/server/services/__tests__/test.service.test.ts
@@ -1,7 +1,20 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// `any` is used deliberately for lightweight model/service mocks in these tests.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { Types } from 'mongoose';
-import { queryTests, resolveTestIdsByBaselineSnapshot } from '../test.service';
+import { queryTests, resolveTestIdsByBaselineSnapshot, accept } from '../test.service';
+
+// A Check model mock that honours a `{ test, _id: { $in } }` filter, so tests can
+// assert which checks the accept scoping selects.
+const makeAcceptCheckModel = (checks: { _id: string; actualSnapshotId: string }[]) => ({
+    find: (filter: any) => ({
+        exec: async () => {
+            const idIn: string[] | undefined = filter?._id?.$in;
+            return idIn ? checks.filter((c) => idIn.includes(c._id)) : checks;
+        },
+    }),
+});
 
 const makeCheckModel = (distinctResult: Types.ObjectId[]) => ({
     find: () => ({
@@ -27,6 +40,54 @@ test('queryTests returns empty result when baseline snapshot has no tests', asyn
     assert.equal(result.totalPages, 0);
     assert.equal(result.page, 2);
     assert.equal(result.limit, 5);
+});
+
+test('accept scopes to the given checkIds (AI-match / similar subset)', async () => {
+    const allChecks = [
+        { _id: 'c1', actualSnapshotId: 's1' },
+        { _id: 'c2', actualSnapshotId: 's2' },
+        { _id: 'c3', actualSnapshotId: 's3' },
+    ];
+    const accepted: string[] = [];
+    await accept(
+        'test1',
+        { username: 'u' } as any,
+        ['c1', 'c3'],
+        {
+            CheckModel: makeAcceptCheckModel(allChecks) as any,
+            acceptCheck: (async (checkId: string) => { accepted.push(String(checkId)); }) as any,
+        },
+    );
+    assert.deepEqual(accepted.sort(), ['c1', 'c3']);
+});
+
+test('accept without checkIds accepts every check of the test (unchanged)', async () => {
+    const allChecks = [
+        { _id: 'c1', actualSnapshotId: 's1' },
+        { _id: 'c2', actualSnapshotId: 's2' },
+        { _id: 'c3', actualSnapshotId: 's3' },
+    ];
+    const accepted: string[] = [];
+    await accept(
+        'test1',
+        { username: 'u' } as any,
+        undefined,
+        {
+            CheckModel: makeAcceptCheckModel(allChecks) as any,
+            acceptCheck: (async (checkId: string) => { accepted.push(String(checkId)); }) as any,
+        },
+    );
+    assert.deepEqual(accepted.sort(), ['c1', 'c2', 'c3']);
+});
+
+test('accept with an empty checkIds array accepts the whole test (no accidental no-op)', async () => {
+    const allChecks = [{ _id: 'c1', actualSnapshotId: 's1' }, { _id: 'c2', actualSnapshotId: 's2' }];
+    const accepted: string[] = [];
+    await accept('test1', { username: 'u' } as any, [], {
+        CheckModel: makeAcceptCheckModel(allChecks) as any,
+        acceptCheck: (async (checkId: string) => { accepted.push(String(checkId)); }) as any,
+    });
+    assert.deepEqual(accepted.sort(), ['c1', 'c2']);
 });
 
 test('queryTests delegates to paginate with resolved test ids', async () => {

--- a/packages/syngrisi/src/server/services/test.service.ts
+++ b/packages/syngrisi/src/server/services/test.service.ts
@@ -92,7 +92,18 @@ const remove = async (id: string, user: RequestUser) => {
     }
 };
 
-const accept = async (id: string, user: RequestUser) => {
+const accept = async (
+    id: string,
+    user: RequestUser,
+    // When provided, only these checks of the test are accepted (e.g. the "AI
+    // match / similar" grid shows a filtered subset — accepting the test must
+    // not silently accept the hidden, non-matching checks). Empty/undefined =
+    // accept the whole test (unchanged behaviour).
+    checkIds?: string[],
+    deps: { CheckModel?: typeof Check; acceptCheck?: typeof checkService.accept } = {},
+) => {
+    const CheckModel = deps.CheckModel || Check;
+    const acceptCheck = deps.acceptCheck || checkService.accept;
     const logOpts = {
         scope: 'acceptTest',
         itemType: 'test',
@@ -100,12 +111,16 @@ const accept = async (id: string, user: RequestUser) => {
         user: user?.username,
         msgType: 'ACCEPT',
     };
-    log.info(`accept test with, id: '${id}', user: '${user.username}'`, logOpts);
+    const scoped = Array.isArray(checkIds) && checkIds.length > 0;
+    log.info(`accept test with, id: '${id}', user: '${user.username}'${scoped ? `, scoped to ${checkIds!.length} check(s)` : ''}`, logOpts);
 
-    const checks = await Check.find({ test: id }).exec();
+    const filter: FilterQuery<unknown> = scoped
+        ? { test: id, _id: { $in: checkIds } }
+        : { test: id };
+    const checks = await CheckModel.find(filter).exec();
 
     for (const check of checks) {
-        await checkService.accept(check._id, String(check.actualSnapshotId), user);
+        await acceptCheck(check._id, String(check.actualSnapshotId), user);
     }
     return { message: 'success' };
 };

--- a/packages/syngrisi/src/ui-app/index2/components/Tests/Table/AcceptTestModalAsk.tsx
+++ b/packages/syngrisi/src/ui-app/index2/components/Tests/Table/AcceptTestModalAsk.tsx
@@ -4,6 +4,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { TestsService } from '@shared/services';
 import { errorMsg, successMsg } from '@shared/utils/utils';
 import { log } from '@shared/utils/Logger';
+import { useSimilar } from '@hooks/useSimilar';
+import { useParams } from '@hooks/useParams';
 
 interface Props {
     opened: boolean,
@@ -15,10 +17,20 @@ interface Props {
 
 export default function AcceptTestModalAsk({ opened, setOpened, selection, setSelection, infinityQuery }: Props) {
     const queryClient = useQueryClient();
+    const { similarTo, ids } = useSimilar();
+    const { query } = useParams();
+
+    // When the grid is filtered to a subset of checks (AI-match / similar view,
+    // or a triage "_idIn" set), accept must be scoped to exactly those checks —
+    // otherwise the whole test (including the hidden, non-matching checks) would
+    // be accepted. The server intersects this set with each test's own checks.
+    const scopedCheckIds: string[] | undefined = similarTo
+        ? ids
+        : (Array.isArray(query.checkFilter?._idIn) ? query.checkFilter._idIn.map(String) : undefined);
 
     const mutationAcceptTest = useMutation(
         {
-            mutationFn: (data: { id: string }) => TestsService.acceptTest(data),
+            mutationFn: (data: { id: string; checkIds?: string[] }) => TestsService.acceptTest(data),
             onSuccess: async (resp) => {
                 successMsg({ message: 'Test has been successfully accepted' });
                 await queryClient.invalidateQueries({ queryKey: ['preview_checks', resp.id] });
@@ -34,7 +46,7 @@ export default function AcceptTestModalAsk({ opened, setOpened, selection, setSe
     const handleAcceptButtonClick = async () => {
         // eslint-disable-next-line no-restricted-syntax
         for (const id of selection) {
-            asyncMutations.push(mutationAcceptTest.mutateAsync({ id }));
+            asyncMutations.push(mutationAcceptTest.mutateAsync({ id, checkIds: scopedCheckIds }));
         }
         await Promise.all(asyncMutations);
         setSelection(() => []);

--- a/packages/syngrisi/src/ui-app/shared/services/tests.service.ts
+++ b/packages/syngrisi/src/ui-app/shared/services/tests.service.ts
@@ -12,10 +12,10 @@ export const TestsService = {
         return resp.json();
     },
 
-    async acceptTest({ id }: { id: string }) {
+    async acceptTest({ id, checkIds }: { id: string; checkIds?: string[] }) {
         const resp = await http.put(
             `${config.baseUri}/v1/tests/accept/${id}`,
-            undefined,
+            checkIds && checkIds.length > 0 ? { checkIds } : undefined,
             {},
             'TestsService.acceptTest'
         );


### PR DESCRIPTION
## Summary

Fixes a bug in the **AI match / similar** view: accepting from the filtered grid
accepted the **whole test**, not just the similar checks shown. The grid filters
checks (via `_idIn`) but the bulk "accept tests" action ran at test granularity
and accepted every check of the test — including the hidden, non-matching ones.

## Fix

`test.accept` now takes an optional `checkIds` filter and scopes the query:
`Check.find({ test: id, _id: { $in: checkIds } })` when provided, whole test
otherwise (unchanged). Wired through:
- `PUT /v1/tests/accept/:id` — optional, validated request body `{ checkIds }`
- controller reads `checkIds`, client `acceptTest({ id, checkIds })`
- `AcceptTestModalAsk` passes the currently filtered check ids (similar set or
  triage `_idIn`); the server intersects them with each selected test's checks,
  so passing the full set is correct across multi-test selections.

## Tests
- `test.service` unit tests for the scoping (TDD — confirmed they fail without
  the fix, pass with it) + the whole-test / empty-array cases
- HTTP-level verification of the endpoint: no body → whole test `200`, valid
  `checkIds` → `200`, malformed `checkIds` → `400`

## Verification
- server tsc **128**, ui tsc **0**, lint **226** (baseline lowered 232→226), server tests **187**
- full chromium E2E: **365 passed, 0 failed** (2 unrelated RCA flakies)

## Changeset
`@syngrisi/syngrisi` (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
